### PR TITLE
Feat: Setup FastAPI routing and /predict endpoint stub for pre-annota…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,121 @@
-# DataCreative
+```markdown
+# Agile AI Vision Application
+
+This project implements the "Agile AI Vision Application" as described in the technical architecture and implementation blueprint. It aims to provide a system for non-technical users to rapidly iterate on AI vision models through a "Data Flywheel" approach, integrating object detection, user-guided correction, intelligent data synthesis, and rapid model adaptation.
+
+## Project Structure
+
+```
+ agile-ai-vision/
+ │
+ ├── backend_api/           # FastAPI application (Business Logic/API Layer)
+ │   ├── app/
+ │   │   ├── main.py         # FastAPI app instantiation
+ │   │   ├── api/            # API endpoint definitions
+ │   │   ├── core/           # Core logic, config
+ │   │   ├── models/         # Pydantic models
+ │   │   ├── services/       # Business logic services
+ │   │   └── db/             # Database related modules
+ │   ├── Dockerfile
+ │   └── requirements.txt
+ │
+ ├── model_servers/         # AI Model Serving Layer components
+ │   ├── yolo_uniow/         # YOLO-UniOW model server
+ │   │   ├── Dockerfile
+ │   │   ├── requirements.txt
+ │   │   └── serve.py
+ │   ├── grounding_dino/     # Placeholder
+ │   ├── gligen/             # Placeholder
+ │   ├── controlnet_sd3/     # Placeholder
+ │   └── internvl2/          # Placeholder
+ │
+ ├── label_studio_ml_backend/ # Scripts for Label Studio ML Backend integration
+ │   └── yolo_preannotation_backend.py
+ │
+ ├── data/                    # Local data storage (mounted into Docker)
+ │   ├── images/
+ │   ├── database/
+ │   │   └── metadata.db
+ │   └── label_studio_data/
+ │
+ ├── docs/                    # Design documents
+ │   ├── prd.md
+ │   └── architecture_design.md
+ │
+ ├── scripts/                 # Utility scripts (e.g., model fine-tuning)
+ │
+ ├── docker-compose.yml       # Main Docker Compose file
+ ├── .env.example             # Example environment variables
+ └── README.md                # This file
+```
+
+## Prerequisites
+
+*   Docker
+*   Docker Compose (usually included with Docker Desktop)
+*   NVIDIA GPU and NVIDIA Docker support (if using GPU acceleration for models)
+
+## Setup
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd agile-ai-vision
+    ```
+
+2.  **Environment Variables:**
+    Copy `.env.example` to `.env` and customize if necessary.
+    ```bash
+    cp .env.example .env
+    ```
+    Key variables to check:
+    *   `LABEL_STUDIO_USERNAME` / `LABEL_STUDIO_PASSWORD` in `docker-compose.yml` (or configure via `.env` if you modify docker-compose to use them).
+    *   The `FASTAPI_BACKEND_URL` in `label_studio_ml_backend/yolo_preannotation_backend.py` should be correctly set to where the `backend_api` service's `/predict` (or relevant endpoint) is accessible from the ML backend script's perspective. If the ML backend script is run by Label Studio *outside* the main docker-compose network (e.g., on host), this might be `http://localhost:8000/predict`. If the ML backend script is *also* a Docker container within the `agile_ai_network`, it would be `http://backend_api:8000/predict`. For now, `yolo_preannotation_backend.py` defaults to `http://backend_api:8000/api/v1/predict` which implies the FastAPI router in `main.py` should be configured with `/api/v1` prefix for its endpoints. *(Note: The current `main.py` and `endpoints.py` stubs do not yet include the `/api/v1` prefix; this will need to be added or the URL adjusted).*
+
+3.  **Create Data Directories:**
+    The `docker-compose.yml` expects certain directories under `./data/` for persistent storage. Create them if they don't exist:
+    ```bash
+    mkdir -p ./data/images/project_1/original ./data/images/project_1/generated
+    mkdir -p ./data/database
+    mkdir -p ./data/label_studio_data
+    ```
+
+4.  **Build and Run with Docker Compose:**
+    ```bash
+    docker-compose up --build -d
+    ```
+    *   `--build` forces a rebuild of images if Dockerfiles have changed.
+    *   `-d` runs containers in detached mode.
+
+5.  **Access Label Studio:**
+    Open your browser and go to `http://localhost:8080`. Log in with the credentials you set (default: `admin@example.com` / `password` in `docker-compose.yml`).
+
+6.  **Configure ML Backend in Label Studio:**
+    This step requires the `yolo_preannotation_backend.py` script to be running as a server that Label Studio can connect to.
+    1.  You would typically run the ML backend script using `label-studio-ml start path/to/label_studio_ml_backend/`. This script needs its `FASTAPI_BACKEND_URL` environment variable set to `http://backend_api:8000` (or `http://host.docker.internal:8000` if the ML script runs on the host and needs to reach the Dockerized `backend_api`).
+    2.  In Label Studio UI (Project Settings -> Machine Learning -> Add Model), you would add the URL where the ML backend script is listening (e.g., `http://<ip_of_ml_backend_script_host>:9090`).
+    *(This part of the setup needs careful handling of networking between Label Studio, the ML backend script, and the FastAPI service).*
+
+## Development
+
+*   **Backend API (`backend_api`):** FastAPI for business logic and communication between Label Studio and model servers.
+*   **Model Servers (`model_servers/*`):** Individual FastAPI/TorchServe/etc. servers for each AI model.
+*   **Label Studio ML Backend (`label_studio_ml_backend`):** Python scripts using `label-studio-ml` library to integrate with Label Studio.
+
+### To run linters/formatters (example using ruff):
+Ensure ruff is installed in your environment or run it via docker.
+```bash
+# For backend_api (from project root)
+# ruff check backend_api/
+# ruff format backend_api/
+```
+
+## Future Work (High Level)
+*   Refine ML Backend integration with Label Studio within the Docker Compose setup.
+*   Implement actual model loading and inference in `model_servers`.
+*   Complete database schema and CRUD operations in `backend_api`.
+*   Flesh out Label Studio ML backend scripts for all functionalities (generation, suggestions).
+*   Develop the model fine-tuning script.
+*   Add more robust error handling, logging, and testing.
+*   Ensure the FastAPI router in `backend_api/app/main.py` uses a prefix like `/api/v1` and update `FASTAPI_BACKEND_URL` in `yolo_preannotation_backend.py` accordingly.
+```

--- a/architecture_design.md
+++ b/architecture_design.md
@@ -1,0 +1,470 @@
+```markdown
+# Architecture Design Document: Agile AI Vision Application
+
+## 1. Introduction
+
+### 1.1. Purpose of this Document
+This document provides a comprehensive architectural overview of the Agile AI Vision Application. It details the system's components, their interactions, data flows, technology stack, and deployment strategy. This document is intended for software engineers, system architects, and technical stakeholders involved in the development, deployment, and maintenance of the system.
+
+### 1.2. Scope
+The scope of this architecture document covers all major components of the system, including the user interface, application server, business logic/API layer, AI model serving infrastructure, and data persistence mechanisms, as outlined in the source "敏捷AI视觉应用" whitepaper.
+
+### 1.3. Goals and Non-Goals of the Architecture
+**Goals:**
+*   **Modularity:** Design components that are loosely coupled and can be developed, deployed, and scaled independently.
+*   **User-Centricity:** Prioritize ease of use for non-technical users through the Label Studio interface and streamlined workflows.
+*   **Extensibility:** Allow for the future integration of new AI models, data sources, and functionalities.
+*   **Rapid Iteration Support:** The architecture must inherently support the "Data Flywheel" concept, enabling quick updates to models based on user feedback and generated data.
+*   **Local First Deployment:** Fulfill the initial requirement for local file system storage and operation, while paving the way for potential future cloud scalability.
+
+**Non-Goals (for initial MVP/Phases):**
+*   Achieving web-scale scalability with millions of concurrent users.
+*   Providing a fully managed cloud service.
+*   Advanced, enterprise-grade security features beyond standard practices for local deployments.
+*   Real-time, multi-user collaborative editing beyond Label Studio's native capabilities.
+
+### 1.4. References
+*   Product Requirements Document: Agile AI Vision Application (`prd.md`)
+*   Source Document: "面向非技术用户的敏捷AI视觉应用：技术架构与实施蓝图" (referred to as "Source Whitepaper")
+
+### 1.5. Definitions and Acronyms
+*   **AI:** Artificial Intelligence
+*   **API:** Application Programming Interface
+*   **CVAT:** Computer Vision Annotation Tool
+*   **GLIGEN:** Grounded-Language-to-Image Generation
+*   **KPI:** Key Performance Indicator
+*   **LMM:** Large Multimodal Model
+*   **mAP:** mean Average Precision
+*   **ML:** Machine Learning
+*   **MVP:** Minimum Viable Product
+*   **OVD:** Open Vocabulary Object Detection
+*   **OWOD:** Open World Object Detection
+*   **PRD:** Product Requirements Document
+*   **SD3:** Stable Diffusion 3
+*   **UI:** User Interface
+*   **FS:** File System
+
+## 2. System Overview
+
+### 2.1. Architectural Vision (Reiteration of the Data Flywheel)
+The core architectural vision is to realize the "Data Flywheel" concept described in the Source Whitepaper (Part 1.2). This entails a closed-loop system where:
+1.  **Detection & Gap Identification:** AI models (primarily YOLO-UniOW) process images, identifying known objects and flagging unknowns.
+2.  **User-Guided Correction & Augmentation:** Non-technical users correct errors and initiate data generation via Label Studio.
+3.  **Intelligent Data Synthesis:** Generative AI models (GLIGEN, ControlNet) create new, annotated data based on user input.
+4.  **Rapid Model Adaptation:** Corrected and synthesized data are used to quickly fine-tune AI models, enhancing their performance for the next cycle.
+This iterative process, orchestrated through a user-friendly interface, aims to continuously improve model accuracy and adapt to new requirements with minimal friction.
+
+### 2.2. High-Level Architecture Diagram
+The system follows a layered architecture, as depicted in Figure 5.1 of the Source Whitepaper.
+
+*(Placeholder for re-creating or referencing Figure 5.1: End-to-end system architecture图)*
+*   **Presentation Layer:** User's Web Browser (Label Studio Frontend)
+*   **Application Layer:** Label Studio Server (with ML Backend)
+*   **Business Logic/API Layer:** Python FastAPI Service
+*   **Model Serving Layer:** Dedicated AI Model Inference Servers (e.g., Triton, TorchServe, Custom)
+*   **Data Persistence Layer:** Local File System + SQLite
+
+### 2.3. Key Architectural Principles
+*   **Separation of Concerns:** Each layer and component has distinct responsibilities. For example, Label Studio handles UI and annotation workflow, FastAPI handles API requests and business logic, and model servers handle computationally intensive AI inference.
+*   **API-Driven Communication:** Interactions between layers (e.g., Label Studio ML Backend to FastAPI, FastAPI to Model Servers) are managed through well-defined APIs.
+*   **Modularity for AI Models:** AI models are treated as interchangeable components within the Model Serving Layer, allowing for updates or replacements with minimal impact on other parts of the system.
+*   **User Experience Prioritization:** The choice of Label Studio and the design of interaction workflows are geared towards non-technical users.
+*   **Pragmatic Local Deployment:** The initial design focuses on a Docker-compose based local deployment to meet user requirements, using local file systems and SQLite for simplicity and ease of setup.
+*   **Designed for Extensibility:** While starting local, the architecture anticipates future needs for scalability by abstracting data access and separating model serving, which could be scaled or moved to the cloud.
+
+## 3. Layered Architecture (Detailed from Part 5.1 of Source Whitepaper)
+
+### 3.1. Presentation Layer (Label Studio Front-end)
+*   **Responsibilities:**
+    *   Provides the primary graphical user interface (GUI) for all user interactions.
+    *   Renders images, annotations (bounding boxes, labels), and model suggestions.
+    *   Captures user inputs for annotation, correction, data generation triggers, and prompt formulation.
+    *   Initiates requests to the Application Layer (Label Studio Server) for backend processing.
+*   **Key Technologies:** Standard web technologies (HTML, CSS, JavaScript) as part of the Label Studio front-end application.
+*   **User Interaction Points for AI Features:**
+    *   Viewing pre-annotations from YOLO-UniOW.
+    *   Correcting/labeling "unknown" objects.
+    *   Defining new class labels.
+    *   Buttons/forms to trigger GLIGEN object generation (specifying location and prompt).
+    *   Buttons/forms to trigger ControlNet scene editing (specifying mask and prompt).
+    *   Interface elements to request and select prompt suggestions from InternVL2.
+
+### 3.2. Application Layer (Label Studio Server + ML Backend)
+*   **Responsibilities:**
+    *   Manages user accounts, projects, tasks, and data within Label Studio.
+    *   Orchestrates the overall annotation and data iteration workflow.
+    *   Serves the Label Studio front-end to the user's browser.
+    *   Crucially, its **ML Backend** component acts as a bridge, forwarding requests from the UI that require AI processing to the Business Logic/API Layer and returning results.
+*   **Key Technologies:** Label Studio application (Python-based), Label Studio ML Backend SDK/API.
+
+### 3.3. Business Logic / API Layer (Python FastAPI Service)
+*   **Responsibilities:**
+    *   Exposes a set of RESTful API endpoints that the Label Studio ML Backend consumes.
+    *   Receives requests from Label Studio (e.g., for pre-annotation, image generation).
+    *   Validates and processes these requests.
+    *   Intelligently routes requests to the appropriate AI model(s) in the Model Serving Layer.
+    *   Handles interactions with the Data Persistence Layer for creating, reading, updating, and deleting metadata (e.g., storing new annotations, paths to generated images).
+    *   Formats responses (e.g., annotation data, generated image paths, prompt suggestions) to be sent back to Label Studio.
+*   **Key Technologies:** Python 3.10+, FastAPI framework for building high-performance APIs, Pydantic for data validation.
+*   **Core API Endpoint Categories:** (Details in Section 6)
+    *   Prediction/Pre-annotation endpoints.
+    *   Data generation endpoints (object植入, scene editing).
+    *   Prompt assistance endpoints.
+    *   (Future) Model training/adaptation trigger endpoints.
+
+### 3.4. Model Serving Layer
+*   **Responsibilities:**
+    *   Hosts and manages the lifecycle of all AI models.
+    *   Provides high-performance inference services for the AI models.
+    *   Exposes internal API endpoints (e.g., HTTP or gRPC) that the Business Logic/API Layer can call to get predictions or generated content from the models.
+    *   Handles model-specific pre-processing and post-processing of data if not covered by the FastAPI layer.
+*   **Key Technologies:**
+    *   Options include NVIDIA Triton Inference Server, TorchServe, or custom Python-based model servers (e.g., using Flask/FastAPI with `diffusers` library for generative models). The choice may depend on the specific model and performance requirements.
+    *   Docker for containerizing each model service.
+*   **Deployment Strategy for Models:** Each AI model (or closely related group of models) will be packaged as a separate Docker container/service, allowing for independent scaling, updating, and resource allocation.
+
+### 3.5. Data Persistence Layer
+*   **Responsibilities:**
+    *   Stores all persistent data required by the application.
+*   **Image Storage (Local File System):**
+    *   **Technology:** User's local file system.
+    *   **Content:** Original uploaded images, synthetically generated images.
+    *   **Structure:** A well-defined directory structure (e.g., per project, with subfolders for originals and generated).
+*   **Metadata Storage (SQLite):**
+    *   **Technology:** SQLite database.
+    *   **Content:** File paths to images, annotation data (bounding box coordinates, class labels, source of annotation), project configurations, user information (if managed by Label Studio), label schemas.
+    *   **Rationale:** Lightweight, file-based, easy to set up for local deployments, and adequate for MVP and small to medium-sized projects.
+*   **Data Access Abstraction (Design Consideration):**
+    *   The Business Logic/API Layer should interact with the data stores (FS and SQLite) through an abstracted Data Access Layer (DAL). This means specific file system paths or SQL queries are encapsulated within this DAL.
+    *   **Benefit:** This design significantly simplifies future migration to alternative storage solutions (e.g., cloud object storage like AWS S3, and managed databases like PostgreSQL or MySQL) by localizing the necessary code changes to the DAL, rather than requiring modifications throughout the Business Logic Layer. Label Studio itself also supports cloud storage, which would facilitate such a transition.
+
+## 4. Component Deep Dive: AI Models (Hosted in Model Serving Layer)
+This section details the specific AI models chosen for the system, their roles, and key features leveraged, as primarily discussed in Part 2 and 3 of the Source Whitepaper. Each model will be served as a distinct service within the Model Serving Layer.
+
+### 4.1. Real-time Detection: YOLO-UniOW
+*   **Role in System:** Primary engine for real-time, interactive object detection and pre-annotation directly within the user interface. It is the first model to process user-uploaded images.
+*   **Key Features Leveraged:**
+    *   **High Efficiency & Speed:** Suitable for immediate feedback in interactive web applications (Targeting ~64.8 FPS for YOLO-UniOW-L on A100, per Source Whitepaper Table 2.1).
+    *   **Open Vocabulary Detection (OVD):** Allows detection of object categories defined dynamically by user text prompts.
+    *   **"通配符学习" (Wildcard Learning - OWOD):** Crucially, it can identify objects not belonging to any known vocabulary as "unknown," proactively highlighting potential new categories or missed detections. This directly supports the "Detect & Identify Gaps" phase of the Data Flywheel and simplifies user workflow from "search for errors" to "review suggestions."
+*   **Integration:** Called by the FastAPI backend when Label Studio requests pre-annotations for a new image. Returns bounding boxes, class labels (if known), and "unknown" tags.
+
+### 4.2. High-Accuracy Detection: Grounding DINO
+*   **Role in System:** Serves as a high-precision, offline analysis tool. Used when accuracy is more critical than real-time speed.
+*   **Key Features Leveraged:**
+    *   **State-of-the-Art Zero-Shot Accuracy:** Provides highly accurate localization and classification based on text prompts, even for objects not seen during its COCO training (Source Whitepaper Sec 2.2).
+    *   **Deep Visual-Language Fusion:** Enables precise understanding of text-image relationships.
+*   **Integration:**
+    *   Can be used by the FastAPI backend for batch processing tasks (not directly user-facing in real-time).
+    *   Potentially used as a "precision locator" to provide accurate bounding boxes as input/conditioning for the GLIGEN generation model, ensuring generated objects are placed precisely.
+
+### 4.3. Object植入式生成 (Object In-place Generation): GLIGEN
+*   **Role in System:** Enables users to add new objects to existing images or backgrounds by specifying a location (bounding box) and a textual description. Core to "从零生成" (generate from scratch) and "增量生成" (incremental generation) for data augmentation.
+*   **Key Features Leveraged:**
+    *   **Grounded Generation:** Generates objects conditioned on both text prompts and spatial location (bounding box) inputs.
+    *   **Leverages Pre-trained Diffusion Models (e.g., Stable Diffusion):** Builds upon strong existing generative capabilities, freezing their weights and adding trainable Gated Self-Attention layers for control.
+*   **Integration:** Called by the FastAPI backend when a user initiates an "object植入" task from Label Studio. Receives background image, bounding box coordinates, and text prompt. Returns the new image with the generated object, and the FastAPI service will also record the new annotation.
+
+### 4.4. Scene-Aware Repair/Inpainting: ControlNet + SD3 (Stable Diffusion 3)
+*   **Role in System:** Provides advanced capabilities for more complex image editing, such as seamlessly replacing objects or modifying regions while maintaining overall scene consistency (lighting, perspective). Used for "修正模型漏检错检" (correcting model false positives/negatives) in complex ways.
+*   **Key Features Leveraged:**
+    *   **Conditional Inpainting:** Modifies user-defined masked regions based on textual prompts.
+    *   **Spatial Condition Control:** Utilizes control signals (e.g., depth maps, Canny edges extracted from the original image) to ensure the generated content aligns realistically with the surrounding scene structure and geometry. SD3 integration enhances this capability.
+*   **Integration:** Called by the FastAPI backend when a user initiates an "edit scene" or "inpaint" task. Receives original image, mask, text prompt, and potentially control images (like a depth map automatically extracted by the backend). Returns the modified image.
+
+### 4.5. Prompt Assistance: InternVL2
+*   **Role in System:** Acts as a "提示词副驾驶" (Prompt Co-pilot) to help non-technical users formulate effective and diverse textual prompts for the generative models (GLIGEN, ControlNet).
+*   **Key Features Leveraged:**
+    *   **Advanced Text Generation:** Capable of understanding simple user inputs (e.g., a basic category name like "安全帽") and expanding them into a set of rich, descriptive prompt templates.
+    *   **Large Knowledge Base (from LMM pre-training):** Can generate varied prompts covering different styles, contexts, and attributes for the desired object/scene.
+*   **Integration:** Called by the FastAPI backend when a user requests prompt suggestions within the generation workflow in Label Studio. Receives a basic concept/keyword from the user. Returns a list of suggested, more detailed prompts.
+
+## 5. Data Models and Schemas
+This section will detail the structure of data as it's stored and transferred within the system.
+
+### 5.1. Image Metadata (SQLite Schema - Preliminary)
+The SQLite database will store metadata. Below is a preliminary schema design.
+
+*   **Projects Table:**
+    *   `project_id` (INTEGER, Primary Key, Autoincrement)
+    *   `project_name` (TEXT, Not Null, Unique)
+    *   `description` (TEXT)
+    *   `creation_date` (TIMESTAMP, Default CURRENT_TIMESTAMP)
+    *   `config_json` (TEXT)  -- Stores Label Studio labeling config, etc.
+
+*   **Images Table:**
+    *   `image_id` (INTEGER, Primary Key, Autoincrement)
+    *   `project_id` (INTEGER, Foreign Key to Projects)
+    *   `original_file_path` (TEXT, Not Null) -- Path in the local FS
+    *   `generated_file_path` (TEXT, Nullable) -- Path if this is an AI-generated image
+    *   `width` (INTEGER)
+    *   `height` (INTEGER)
+    *   `upload_date` (TIMESTAMP, Default CURRENT_TIMESTAMP)
+    *   `source_image_id` (INTEGER, Foreign Key to Images, Nullable) -- If generated, links to base image
+    *   `generation_params_json` (TEXT, Nullable) -- Prompt, model used for generation
+
+*   **Labels Table (Object Categories):**
+    *   `label_id` (INTEGER, Primary Key, Autoincrement)
+    *   `project_id` (INTEGER, Foreign Key to Projects)
+    *   `label_name` (TEXT, Not Null)
+    *   `color_hex` (TEXT) -- Optional, for UI display
+    *   UNIQUE (`project_id`, `label_name`)
+
+*   **Annotations Table (Bounding Boxes):**
+    *   `annotation_id` (INTEGER, Primary Key, Autoincrement)
+    *   `image_id` (INTEGER, Foreign Key to Images)
+    *   `label_id` (INTEGER, Foreign Key to Labels)
+    *   `x_min` (REAL, Not Null) -- Bounding box coordinate (normalized or absolute)
+    *   `y_min` (REAL, Not Null)
+    *   `x_max` (REAL, Not Null)
+    *   `y_max` (REAL, Not Null)
+    *   `confidence_score` (REAL, Nullable) -- If from AI model
+    *   `source_type` (TEXT) -- e.g., 'manual', 'yolo-uniow', 'gligen_generated', 'grounding_dino'
+    *   `is_unknown` (BOOLEAN, Default FALSE) -- If flagged as 'unknown' by OWOD model
+    *   `creation_date` (TIMESTAMP, Default CURRENT_TIMESTAMP)
+    *   `last_modified_date` (TIMESTAMP)
+
+### 5.2. Data Structures for API Communication (Pydantic Models for FastAPI)
+FastAPI will use Pydantic models for request and response validation and serialization. Examples:
+
+*   **`ImageUploadRequest`**: May contain file metadata, project ID.
+*   **`PredictionRequest`**: Contains image ID or path, project ID (to get relevant labels).
+*   **`BoundingBox`**: `x_min, y_min, x_max, y_max, label_name, confidence_score`.
+*   **`PredictionResponse`**: List of `BoundingBox` objects.
+*   **`ObjectGenerationRequest`**: `base_image_id, target_bbox, text_prompt, project_id`.
+*   **`ObjectGenerationResponse`**: `new_image_path, generated_bbox_annotation`.
+*   **`SceneEditRequest`**: `base_image_id, mask_image_path_or_data, text_prompt, project_id`.
+*   **`SceneEditResponse`**: `edited_image_path`.
+*   **`PromptSuggestionRequest`**: `base_keyword, project_id`.
+*   **`PromptSuggestionResponse`**: List of suggested prompts.
+
+These will be defined in detail within the FastAPI application code.
+
+## 6. API Specifications (FastAPI Backend)
+The FastAPI service will expose endpoints for the Label Studio ML Backend. All interactions are initiated by Label Studio calling these endpoints.
+
+### 6.1. ML Backend API for Label Studio
+
+*   **`POST /predict` (for pre-annotation with YOLO-UniOW)**
+    *   **Request Body:** `PredictionRequest` (e.g., list of tasks/images, labeling config from LS).
+    *   **Response Body:** List of predictions in Label Studio format. Each prediction contains bounding boxes with labels (or "unknown").
+    *   **Action:** Retrieves image(s), sends to YOLO-UniOW service, formats results.
+
+*   **`POST /generate_object` (for GLIGEN)**
+    *   **Request Body:** `ObjectGenerationRequest` (containing background image path/ID, user-drawn bounding box for placement, text prompt, project ID).
+    *   **Response Body:** `ObjectGenerationResponse` (path to the newly generated image, and its annotation).
+    *   **Action:** Retrieves background, calls GLIGEN service, saves new image, stores metadata and annotation in DB.
+
+*   **`POST /edit_scene` (for ControlNet)**
+    *   **Request Body:** `SceneEditRequest` (background image path/ID, mask, text prompt, project ID).
+    *   **Response Body:** `SceneEditResponse` (path to the edited image).
+    *   **Action:** Retrieves image, (optionally extracts control map like depth), calls ControlNet service, saves new image, stores metadata. (Annotation might need user review).
+
+*   **`POST /suggest_prompts` (for InternVL2)**
+    *   **Request Body:** `PromptSuggestionRequest` (user's basic keyword/concept, project ID).
+    *   **Response Body:** `PromptSuggestionResponse` (list of detailed prompt strings).
+    *   **Action:** Calls InternVL2 service with the keyword.
+
+*   **`POST /setup` (ML Backend initial handshake - optional but good practice)**
+    *   **Request Body:** Labeling configuration from Label Studio.
+    *   **Response Body:** Model information (e.g., available labels if the model is already trained, though for OVD it's dynamic).
+    *   **Action:** Initialize or validate model state based on LS project config.
+
+*   **`POST /train` (to trigger model adaptation - simplified for MVP)**
+    *   **Request Body:** Could be as simple as a project ID or a signal to use all new data.
+    *   **Response Body:** Status message (e.g., "Training initiated").
+    *   **Action (MVP):** Triggers a script that prepares data from SQLite and local FS for the specified project and starts a fine-tuning process for YOLO-UniOW.
+    *   **Action (Future):** More sophisticated data selection, versioning, and tracking.
+
+### 6.2. Internal API Endpoints
+The FastAPI service itself will call internal APIs exposed by the individual model servers in the Model Serving Layer. These are not directly exposed to Label Studio. For example:
+*   YOLO-UniOW service might have a `/infer` endpoint.
+*   GLIGEN service might have a `/generate` endpoint.
+These will be simple HTTP endpoints, likely also using FastAPI or Flask if custom-built.
+
+## 7. Data Flow Scenarios (Detailed from Part 5.2 of Source Whitepaper)
+
+### 7.1. Scenario A: Correcting a Missed Detection / Unknown Object
+1.  **Upload & Pre-annotation Request (User -> LS Frontend -> LS Server -> FastAPI):**
+    *   User uploads `image_A.jpg` to Project `P1` in Label Studio.
+    *   LS Frontend sends `image_A.jpg` and `P1` info to LS Server.
+    *   LS Server's ML Backend calls FastAPI's `/predict` endpoint with `image_A.jpg` data and `P1`'s labeling config.
+2.  **Detection (FastAPI -> YOLO-UniOW Service -> FastAPI):**
+    *   FastAPI service receives the request. It prepares the image and calls the YOLO-UniOW model service (hosted in Model Serving Layer).
+    *   YOLO-UniOW processes `image_A.jpg`. It detects known object `Obj1` and an "unknown" object `Unk1`.
+    *   YOLO-UniOW service returns `[{bbox_Obj1, label_Obj1}, {bbox_Unk1, label_unknown}]` to FastAPI.
+3.  **Pre-annotation Response (FastAPI -> LS Server -> LS Frontend -> User):**
+    *   FastAPI formats these results into Label Studio's expected prediction format.
+    *   FastAPI returns the formatted predictions to LS Server's ML Backend.
+    *   LS Server passes results to LS Frontend.
+    *   User sees `image_A.jpg` with a box around `Obj1` (labeled `label_Obj1`) and a box around `Unk1` (labeled "unknown").
+4.  **User Correction & Save (User -> LS Frontend -> LS Server -> FastAPI):**
+    *   User inspects `Unk1`. It's actually a "新型号传感器" (New Model Sensor).
+    *   User changes the label of `bbox_Unk1` from "unknown" to "新型号传感器" (this might involve adding "新型号传感器" to the project's label config if it's new). User clicks "Save" or "Submit" in Label Studio.
+    *   LS Frontend sends the updated annotation task (with `image_A.jpg`, `bbox_Unk1`, and new label "新型号传感器") to LS Server.
+5.  **Data Persistence (LS Server -> FastAPI -> SQLite/FS):**
+    *   LS Server (on task completion/submission) sends the final annotations to a persistence endpoint in FastAPI (or FastAPI infers changes based on prediction ID and user actions if LS ML backend supports this feedback loop directly).
+    *   FastAPI service updates/creates an annotation record in the SQLite `Annotations` table for `image_A.jpg`, linking `bbox_Unk1` to the "新型号传感器" label. The `is_unknown` flag is set to `FALSE`, and `source_type` might be updated to 'manual_correction_of_unknown'.
+
+### 7.2. Scenario B: Adding a New Category with Generative Augmentation
+1.  **Define New Category (User -> LS Frontend -> LS Server):**
+    *   User adds "蓝色小部件" (Blue Widget) to Project `P2`'s label configuration in Label Studio.
+2.  **Initiate Generation (User -> LS Frontend):**
+    *   User uploads `background_B.jpg` to `P2`.
+    *   User clicks a custom "Generate Object" button in the Label Studio interface for `background_B.jpg`.
+3.  **Provide Parameters & Prompt Assistance (User -> LS Frontend -> LS Server -> FastAPI -> InternVL2 -> ... -> User):**
+    *   A dialog appears in LS Frontend. User draws a bounding box (`target_bbox`) on `background_B.jpg`.
+    *   User initially types "blue widget" as a prompt.
+    *   User clicks "Get Prompt Suggestions."
+        *   LS Frontend sends "blue widget" via LS Server's ML Backend to FastAPI's `/suggest_prompts` endpoint.
+        *   FastAPI calls the InternVL2 model service.
+        *   InternVL2 returns a list like ["a glossy blue cylindrical widget", "a small matte blue widget with metallic flecks"].
+        *   FastAPI forwards this list back to LS Frontend.
+    *   User selects "a glossy blue cylindrical widget" as the final prompt.
+4.  **Generation Request (LS Frontend -> LS Server -> FastAPI):**
+    *   User confirms. LS Frontend sends `background_B.jpg` data, `target_bbox`, and the chosen prompt to LS Server.
+    *   LS Server's ML Backend calls FastAPI's `/generate_object` endpoint.
+5.  **Object Generation (FastAPI -> GLIGEN Service -> FastAPI):**
+    *   FastAPI receives the request. It calls the GLIGEN model service with `background_B.jpg`, `target_bbox`, and the prompt.
+    *   GLIGEN service generates `generated_C.jpg` containing the blue widget in the specified location.
+    *   GLIGEN service returns the path/data of `generated_C.jpg` to FastAPI.
+6.  **Data Persistence & Response (FastAPI -> SQLite/FS; FastAPI -> LS Server -> LS Frontend -> User):**
+    *   FastAPI saves `generated_C.jpg` to the local file system (e.g., under `P2/generated/`).
+    *   FastAPI creates new records in SQLite:
+        *   An entry in `Images` for `generated_C.jpg` (linking to `background_B.jpg` as source).
+        *   An entry in `Annotations` for `generated_C.jpg`, with `target_bbox` and the label "蓝色小部件", `source_type` = 'gligen_generated'.
+    *   FastAPI returns the path to `generated_C.jpg` and its annotation to LS Server's ML Backend.
+    *   LS Server could then make this new image available in the project, possibly as a new task with the annotation already applied, for user review or inclusion in the next training round.
+
+## 8. Technology Stack Summary (From Part 5.3 of Source Whitepaper)
+
+| Component             | Technology Chosen        | Reason                                                                                    |
+|-----------------------|--------------------------|-------------------------------------------------------------------------------------------|
+| **Annot. Interface/Orchestrator** | Label Studio             | Excellent ML integration (ML Backend), modern UI, open-source.                            |
+| **Application Backend (API Layer)** | Python 3.10+, FastAPI    | High performance, modern async framework, easy REST API development, Pydantic validation. |
+| **Real-time Detection Model** | YOLO-UniOW               | SOTA speed, revolutionary "Wildcard Learning" for unknown objects.                      |
+| **High-Accuracy Detection Model** | Grounding DINO           | SOTA precision, vital for high-quality localization (e.g., for GLIGEN).                 |
+| **Object Generation Model** | GLIGEN                   | Specialized in grounded/localized object generation based on bbox and text.             |
+| **Scene Editing Model** | ControlNet for SD3       | Flexible scene editing with strong spatial control, enhanced by SD3 capabilities.         |
+| **Prompt Assistance Model** | InternVL2                | Powerful open-source LMM for generating diverse, high-quality text prompts.             |
+| **Data Storage (Images)** | Local File System        | Meets direct user requirement for local storage.                                          |
+| **Data Storage (Metadata)** | SQLite                   | Lightweight, file-based, sufficient for MVP and local metadata management.                |
+| **Deployment Solution** | Docker / Docker Compose  | Simplifies packaging, deployment, management of all microservices; ensures consistency.   |
+| **Core ML Libraries**   | PyTorch, Diffusers, Transformers | Foundational libraries for running and serving the selected AI models.                    |
+
+## 9. Deployment Architecture (From Part 5.3 & 5.4 of Source Whitepaper)
+
+### 9.1. Overview
+The system will be deployed using Docker and Docker Compose. This approach containerizes each component (Label Studio, FastAPI application, individual AI model servers), ensuring environment consistency, simplifying setup, and facilitating management of the interconnected services.
+
+### 9.2. Service Definitions (in `docker-compose.yml`)
+A `docker-compose.yml` file will define the following key services:
+
+*   **`label_studio` service:**
+    *   Based on an official Label Studio Docker image or a custom one if specific plugins/modifications are needed.
+    *   Configured to connect to the `fastapi_app` service for its ML backend.
+    *   Environment variables for database (if LS uses its own SQLite separate from the main one), hostnames, etc.
+    *   Ports exposed (e.g., 8080 for Label Studio UI).
+    *   Volume mounts for Label Studio's own data (projects, configs, task metadata - often an SQLite DB itself) and potentially for access to the shared image data if needed directly (though primary image access for AI tasks is via FastAPI service).
+
+*   **`fastapi_app` service:**
+    *   Based on a custom Docker image built with Python 3.10+, FastAPI, and all necessary dependencies.
+    *   Contains the Business Logic/API Layer code.
+    *   Environment variables for database path (SQLite file path), model server URLs, image storage base path.
+    *   Ports exposed for internal communication from `label_studio` ML backend (e.g., 8000).
+    *   Volume mounts for the SQLite database file and the local file system base path for images.
+
+*   **`yolo_uniow_model_server` service:**
+    *   Custom Docker image containing the YOLO-UniOW model and a serving mechanism (e.g., TorchServe, or a simple FastAPI/Flask wrapper around the model inference script).
+    *   Volume mounts for model weights if not baked into the image.
+    *   Exposes an internal port for inference requests from `fastapi_app`.
+    *   GPU access configured if required (via Docker Compose GPU support).
+
+*   **`grounding_dino_model_server` service:** (Similar structure to YOLO server)
+    *   Custom image for Grounding DINO.
+
+*   **`gligen_model_server` service:** (Similar structure)
+    *   Custom image for GLIGEN, likely using the `diffusers` library. GPU access essential.
+
+*   **`controlnet_model_server` service:** (Similar structure)
+    *   Custom image for ControlNet + SD3. GPU access essential.
+
+*   **`internvl2_model_server` service:** (Similar structure)
+    *   Custom image for InternVL2.
+
+### 9.3. Data Volumes and Persistence
+*   **Image Data:** A Docker named volume or a host path bind-mounted into the `fastapi_app` container (and potentially `label_studio` if it needs direct read access for display, though API-driven is cleaner) to ensure image data persists across container restarts and is accessible by the FastAPI service for processing and delivery to model servers. This volume will point to the user's designated local file system storage area.
+*   **SQLite Database:** The SQLite database file will be stored in a Docker named volume or a host path bind-mounted into the `fastapi_app` container to ensure metadata persistence.
+*   **Label Studio Data:** Label Studio typically uses its own SQLite database for project management. This will also be persisted using a Docker volume.
+*   **Model Weights:** Model weights can either be baked into their respective Docker images or mounted via volumes if they are very large and updated independently of the serving code.
+
+### 9.4. Networking Considerations
+*   Docker Compose will create a default bridge network, allowing services to discover and communicate with each other using their service names as hostnames (e.g., `fastapi_app` can reach `yolo_uniow_model_server` at `http://yolo_uniow_model_server:<port>`).
+*   Only the `label_studio` service's port (e.g., 8080) needs to be published to the host machine for user access. All other inter-service communication can happen on the internal Docker network.
+
+## 10. Scalability and Performance Considerations
+
+### 10.1. Current Limitations (MVP Focus)
+*   **Local File System:** Storage capacity is limited by the user's local disk. Concurrent access performance might be a bottleneck for very high throughput if not managed carefully (though less of an issue for single-user or few-user local setups).
+*   **SQLite:** Suitable for single-process writes and many concurrent reads. Performance can degrade with very large databases or high concurrent write loads, not expected in the initial local deployment scenario.
+*   **Model Serving:** Each model server, if running on shared hardware (especially single GPU), will process requests sequentially or with limited parallelism, impacting throughput for concurrent AI tasks.
+*   **Single `fastapi_app` Instance:** The API layer is a single instance.
+
+### 10.2. Future Scaling Paths
+The current architecture, with its separation of concerns, allows for several scaling avenues if the system were to move to a cloud or more distributed environment:
+*   **Data Storage:**
+    *   Replace local file system with cloud object storage (AWS S3, Google Cloud Storage, Azure Blob Storage). The abstracted Data Access Layer in `fastapi_app` would encapsulate changes. Label Studio also supports these.
+    *   Migrate SQLite to a managed relational database service (AWS RDS, Google Cloud SQL, Azure Database).
+*   **Model Serving:**
+    *   Deploy model servers on dedicated GPU instances.
+    *   Use managed AI inference services (e.g., AWS SageMaker Endpoints, Google AI Platform Prediction, Azure ML Endpoints) which handle auto-scaling.
+    *   Horizontally scale custom model servers (e.g., run multiple Docker containers for a model server behind a load balancer).
+*   **FastAPI Application:**
+    *   Run multiple instances of the `fastapi_app` service behind a load balancer if it becomes a bottleneck (would require stateless design or careful state management if state is introduced).
+*   **Task Queues:** For long-running processes like model training or large batch generation, introduce a task queue (e.g., Celery with RabbitMQ/Redis) to decouple initiation from execution.
+
+## 11. Security Considerations
+
+### 11.1. Access Control
+*   **Label Studio:** Provides its own user authentication and project-based access control. This will be the primary mechanism for controlling who can access which data and perform what actions.
+*   **API Layer (`fastapi_app`):** Since it's primarily called by Label Studio's ML backend, direct user authentication might not be needed at this layer if the network is trusted. However, if exposed more broadly, API key authentication or OAuth2 could be implemented. For inter-service communication (LS ML Backend to FastAPI), a shared secret or token could be used.
+
+### 11.2. API Security (Internal)
+*   The model serving endpoints are internal and should not be exposed publicly. Communication is within the Docker network.
+
+### 11.3. Data Security (Local Deployment)
+*   **File System:** Security of the local file system where images and the SQLite DB are stored is the user's/deployer's responsibility (standard OS file permissions, disk encryption if needed).
+*   **SQLite:** The database file itself should be protected by file system permissions.
+*   No sensitive data like passwords should be hardcoded; use environment variables for configuration.
+
+### 11.4. Container Security
+*   Use official base images where possible.
+*   Keep images updated to patch vulnerabilities.
+*   Run containers with the least privilege necessary.
+
+## 12. Phased Implementation Plan Summary (From Part 5.4 of Source Whitepaper)
+This architecture supports the phased implementation:
+
+*   **Phase 1 (MVP - Core Closed Loop):**
+    *   Deploy `label_studio`, `fastapi_app` (with basic CRUD for SQLite), `yolo_uniow_model_server`.
+    *   Integrate YOLO-UniOW for pre-annotation via LS ML Backend.
+    *   Basic model fine-tuning script (manual trigger).
+    *   Focus: Data upload, pre-annotation, manual correction, data saving, manual model update.
+*   **Phase 2 (Intelligent Generation):**
+    *   Deploy `gligen_model_server`, `controlnet_model_server`.
+    *   Add corresponding API endpoints in `fastapi_app` and UI elements/actions in Label Studio for "generate object" and "edit scene."
+    *   Focus: Enabling user-guided synthetic data generation.
+*   **Phase 3 (Full Automation & UX Optimization):**
+    *   Deploy `internvl2_model_server`.
+    *   Integrate InternVL2 for prompt assistance.
+    *   Develop KPI dashboard.
+    *   Batch processing features.
+    *   Focus: Enhancing user experience, increasing automation, providing performance visibility.
+
+## 13. Open Issues / Future Work (Architecture specific)
+*   **Detailed GPU Management:** For local deployments with multiple models needing GPU, a strategy for sharing or scheduling GPU resources might be needed if a single GPU is available (e.g., Triton's model scheduling or ensuring only one generative model runs at a time).
+*   **Error Handling and Resilience:** Define robust error handling and retry mechanisms between services.
+*   **Configuration Management:** Centralized or more dynamic configuration management if the number of services and parameters grows significantly.
+*   **Logging and Monitoring:** Implement centralized logging (e.g., ELK stack or cloud equivalents) for easier debugging and monitoring across all services in a larger deployment.
+*   **Model Training Orchestration:** For more automated and robust model adaptation, a dedicated training pipeline/orchestration tool (e.g., Kubeflow Pipelines, Apache Airflow) could be integrated in the future, replacing the simple MVP script.
+```

--- a/backend_api/Dockerfile
+++ b/backend_api/Dockerfile
@@ -1,0 +1,25 @@
+```dockerfile
+# Start with a Python base image
+FROM python:3.10-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file first to leverage Docker cache
+COPY requirements.txt requirements.txt
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY ./app /app/app
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Command to run the application using Uvicorn
+# The main:app refers to the 'app' instance in 'main.py'
+# --host 0.0.0.0 makes it accessible from outside the container
+# --reload is useful for development, can be removed for production
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```

--- a/backend_api/app/api/endpoints.py
+++ b/backend_api/app/api/endpoints.py
@@ -6,6 +6,9 @@ import httpx # For making async HTTP requests to model servers
 # Assuming schemas will be defined in backend_api.app.models.schemas
 from ..models import schemas
 from ..core.config import settings # Import settings for model server URLs
+from ..db import crud, database # Import CRUD operations and database session management
+
+from sqlalchemy.orm import Session
 
 router = APIRouter()
 

--- a/backend_api/app/api/endpoints.py
+++ b/backend_api/app/api/endpoints.py
@@ -1,0 +1,228 @@
+```python
+from fastapi import APIRouter, HTTPException, Body, Depends
+from typing import List, Dict, Any
+import httpx # For making async HTTP requests to model servers
+
+# Assuming schemas will be defined in backend_api.app.models.schemas
+from ..models import schemas
+from ..core.config import settings # Import settings for model server URLs
+
+router = APIRouter()
+
+# Dependency for an async HTTP client
+async def get_http_client():
+    async with httpx.AsyncClient() as client:
+        yield client
+
+@router.post("/predict",
+             response_model=List[schemas.LSPredictionItem],
+             summary="Get AI Model Predictions (Pre-annotations)")
+async def predict_annotations(
+    request_data: schemas.LabelStudioRequest, # Use Pydantic model for request validation
+    client: httpx.AsyncClient = Depends(get_http_client)
+) -> List[schemas.LSPredictionItem]:
+    """
+    Endpoint to receive tasks from Label Studio, pass them to an AI model (e.g., YOLO-UniOW),
+    and return predictions in Label Studio format.
+    """
+    print(f"Received /predict request for {len(request_data.tasks)} tasks.")
+
+    api_predictions: List[schemas.LSPredictionItem] = []
+
+    for task in request_data.tasks:
+        image_url_or_path = task.data.get("image") # Assuming 'image' is the key for image path/URL in LS task data
+        if not image_url_or_path:
+            print(f"Task {task.id} missing image data. Skipping.")
+            api_predictions.append(schemas.LSPredictionItem(result=[])) # Empty result for this task
+            continue
+
+        # --------------------------------------------------------------------
+        # TODO: Call the actual YOLO-UniOW model server
+        # This section will be replaced with a real HTTP call to the model server
+        # For now, using mocked response.
+        # --------------------------------------------------------------------
+        print(f"Simulating call to YOLO-UniOW server for task {task.id}, image: {image_url_or_path}")
+        # yolo_request_payload = {"image_path": image_url_or_path, "confidence_threshold": 0.25}
+        # try:
+        #     response = await client.post(settings.YOLO_UNIOW_SERVER_URL, json=yolo_request_payload, timeout=30.0)
+        #     response.raise_for_status()
+        #     yolo_results = response.json().get("predictions", []) # Assuming this is the structure from yolo_uniow_serve.py
+        # except httpx.RequestError as e:
+        #     print(f"Error calling YOLO-UniOW server for task {task.id}: {e}")
+        #     api_predictions.append(schemas.LSPredictionItem(result=[]))
+        #     continue
+        # except Exception as e: # Catch other potential errors like JSON decoding
+        #     print(f"Generic error processing task {task.id} with YOLO-UniOW server: {e}")
+        #     api_predictions.append(schemas.LSPredictionItem(result=[]))
+        #     continue
+        # --------------------------------------------------------------------
+
+        # Mocked YOLO results for demonstration
+        mock_yolo_results = [
+            {"x_min": 10.0, "y_min": 20.0, "x_max": 40.0, "y_max": 60.0, "label": "car", "score": 0.95},
+            {"x_min": 50.0, "y_min": 60.0, "x_max": 80.0, "y_max": 90.0, "label": "person", "score": 0.88},
+            {"x_min": 100.0, "y_min": 100.0, "x_max": 120.0, "y_max": 120.0, "label": "unknown", "score": 0.65}, # Example of 'unknown'
+        ]
+
+        # Determine from_name and to_name from label_config (simplified parsing)
+        # A more robust parsing of label_config XML might be needed for complex configs
+        from_name_found = "label" # Default or parsed
+        to_name_found = "image"   # Default or parsed
+        if request_data.label_config:
+            if "<RectangleLabels" in request_data.label_config:
+                # Simplistic way to get from_name for RectangleLabels
+                try:
+                    from_name_str = request_data.label_config.split('<RectangleLabels name="')[1].split('"')[0]
+                    from_name_found = from_name_str
+                    to_name_str = request_data.label_config.split('toName="')[1].split('"')[0]
+                    to_name_found = to_name_str
+                except IndexError:
+                    print("Could not parse from_name/to_name from label_config, using defaults.")
+
+
+        # Format mock_yolo_results into Label Studio prediction format
+        ls_results_for_task: List[schemas.LSAnnotationResultItem] = []
+        for yolo_pred in mock_yolo_results:
+            ls_results_for_task.append(
+                schemas.LSAnnotationResultItem(
+                    from_name=from_name_found,
+                    to_name=to_name_found,
+                    type="rectanglelabels", # Assuming detection model provides rectangles
+                    value=schemas.LSAnnotationResultItemValue(
+                        rectanglelabels=[yolo_pred["label"]],
+                        x=yolo_pred["x_min"],
+                        y=yolo_pred["y_min"],
+                        width=(yolo_pred["x_max"] - yolo_pred["x_min"]),
+                        height=(yolo_pred["y_max"] - yolo_pred["y_min"]),
+                    ),
+                    score=yolo_pred["score"]
+                )
+            )
+
+        api_predictions.append(schemas.LSPredictionItem(
+            result=ls_results_for_task,
+            score=max((res.score for res in ls_results_for_task if res.score is not None), default=0), # Overall task score
+            model_version=f"mock_yolo_uniow_v0.1_task_{task.id}" # Example model version
+        ))
+
+    return api_predictions
+
+@router.post("/generate_object",
+             response_model=schemas.ObjectGenerationResponse, # Use Pydantic for response
+             summary="Generate Object in Image (GLIGEN)")
+async def generate_object(
+    request_data: schemas.ObjectGenerationRequest, # Use Pydantic for request
+    client: httpx.AsyncClient = Depends(get_http_client)
+) -> schemas.ObjectGenerationResponse:
+    """
+    Endpoint to generate an object in an image using GLIGEN.
+    Expects: background image path, target bounding box, text prompt, project ID.
+    Returns: path to new image and its annotation.
+    """
+    print(f"Received /generate_object request for project {request_data.project_id} on image {request_data.image_path}")
+
+    # TODO:
+    # 1. Construct payload for GLIGEN model server
+    #    gligen_payload = {
+    #        "image_path": request_data.image_path, # This path needs to be accessible by GLIGEN server
+    #        "target_bbox": request_data.target_bbox,
+    #        "text_prompt": request_data.text_prompt
+    #    }
+    # 2. Call GLIGEN model service using 'client' (httpx.AsyncClient)
+    #    response = await client.post(settings.GLIGEN_SERVER_URL, json=gligen_payload, timeout=120.0) # Long timeout for generation
+    #    response.raise_for_status()
+    #    gligen_result = response.json() # e.g., {"generated_image_path_on_server": "..."}
+    # 3. Process result:
+    #    - If GLIGEN server saves the image, determine its path relative to IMAGE_STORAGE_BASE_PATH.
+    #    - Or, if it returns image bytes, save it here.
+    #    - Create an annotation entry in the database for the new object.
+
+    # Mocked response for now
+    mock_new_image_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/project_{request_data.project_id}/generated/gligen_mock_{request_data.image_path.split('/')[-1]}"
+    mock_annotation = schemas.Annotation(
+        image_id=-1, # Placeholder, would come from DB insert of new image
+        label_id=-1, # Placeholder, would come from DB lookup of label by name (derived from prompt or new label)
+        x_min=request_data.target_bbox[0],
+        y_min=request_data.target_bbox[1],
+        x_max=request_data.target_bbox[2],
+        y_max=request_data.target_bbox[3],
+        source_type="gligen_generated"
+    )
+
+    print(f"Mocked GLIGEN generation. Output path: {mock_new_image_path}")
+    return schemas.ObjectGenerationResponse(
+        new_image_path=mock_new_image_path,
+        annotation=mock_annotation
+    )
+
+@router.post("/edit_scene",
+             response_model=schemas.SceneEditResponse,
+             summary="Edit Scene with Inpainting (ControlNet)")
+async def edit_scene(
+    request_data: schemas.SceneEditRequest,
+    client: httpx.AsyncClient = Depends(get_http_client)
+) -> schemas.SceneEditResponse:
+    """
+    Endpoint to edit a scene using ControlNet for inpainting.
+    Expects: background image path, mask data, text prompt, project ID.
+    Returns: path to edited image.
+    """
+    print(f"Received /edit_scene request for project {request_data.project_id} on image {request_data.image_path}")
+    # TODO: Implement call to ControlNet model service
+    # Mocked response
+    mock_edited_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/project_{request_data.project_id}/generated/controlnet_mock_{request_data.image_path.split('/')[-1]}"
+    print(f"Mocked ControlNet edit. Output path: {mock_edited_path}")
+    return schemas.SceneEditResponse(edited_image_path=mock_edited_path)
+
+@router.post("/suggest_prompts",
+             response_model=schemas.PromptSuggestionResponse,
+             summary="Suggest Prompts (InternVL2)")
+async def suggest_prompts(
+    request_data: schemas.PromptSuggestionRequest,
+    client: httpx.AsyncClient = Depends(get_http_client)
+) -> schemas.PromptSuggestionResponse:
+    """
+    Endpoint to get prompt suggestions from InternVL2.
+    Expects: base keyword, optional project ID for context.
+    Returns: list of suggested prompts.
+    """
+    print(f"Received /suggest_prompts request for keyword: {request_data.base_keyword}")
+    # TODO: Implement call to InternVL2 model service
+    # Mocked response
+    mock_suggestions = [
+        f"A high-quality, photorealistic image of a {request_data.base_keyword} in a sunlit environment.",
+        f"Close-up studio shot of a {request_data.base_keyword}, highly detailed.",
+        f"An artistic rendering of a {request_data.base_keyword} in a surreal landscape."
+    ]
+    return schemas.PromptSuggestionResponse(suggestions=mock_suggestions)
+
+@router.post("/setup", summary="ML Backend Setup/Health Check (Optional)")
+async def setup_ml_backend(config: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    """
+    Optional endpoint for Label Studio ML backend to send its configuration
+    and for the backend to return its capabilities or model information.
+    This can be used by the ML backend script on its initialization.
+    """
+    print(f"Received /setup request with config: {config.get('label_config')[:200]}...") # Print snippet of config
+    # You could parse the label_config here if needed to adjust behavior
+    # For now, just acknowledge and return basic model info
+    return {
+        "message": "Backend setup endpoint called successfully.",
+        "model_name": "AgileAIVision_Backend",
+        "capabilities": {
+            "predictions": True,
+            "generations": True,
+            "prompt_suggestions": True
+        }
+    }
+
+# TODO: Add /train endpoint later for model adaptation:
+# @router.post("/train", summary="Trigger Model Adaptation/Fine-tuning")
+# async def train_model(project_id: int = Body(..., embed=True)):
+#     print(f"Received /train request for project_id: {project_id}")
+#     # 1. Logic to gather data for the project (from DB: annotations, image paths)
+#     # 2. Prepare data in the format expected by the training script
+#     # 3. Trigger the training script (e.g., subprocess call, or message queue)
+#     # This is a complex operation and would need careful design.
+#     return {"message": f"Training process initiated for project {project_id} (mocked)."}
+```

--- a/backend_api/app/api/endpoints.py
+++ b/backend_api/app/api/endpoints.py
@@ -1,7 +1,9 @@
 ```python
 from fastapi import APIRouter, HTTPException, Body, Depends
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import httpx # For making async HTTP requests to model servers
+import json # For serializing generation_params
+from datetime import datetime # For filenames
 
 # Assuming schemas will be defined in backend_api.app.models.schemas
 from ..models import schemas
@@ -21,167 +23,231 @@ async def get_http_client():
              response_model=List[schemas.LSPredictionItem],
              summary="Get AI Model Predictions (Pre-annotations)")
 async def predict_annotations(
-    request_data: schemas.LabelStudioRequest, # Use Pydantic model for request validation
-    client: httpx.AsyncClient = Depends(get_http_client)
+    request_data: schemas.LabelStudioRequest,
+    client: httpx.AsyncClient = Depends(get_http_client),
+    db: Session = Depends(database.get_db) # Inject DB session
 ) -> List[schemas.LSPredictionItem]:
     """
     Endpoint to receive tasks from Label Studio, pass them to an AI model (e.g., YOLO-UniOW),
-    and return predictions in Label Studio format.
+    save the predictions to the database, and return predictions in Label Studio format.
     """
-    print(f"Received /predict request for {len(request_data.tasks)} tasks.")
+    print(f"Received /predict request for {len(request_data.tasks)} tasks. Project identifier: {request_data.project}")
 
-    api_predictions: List[schemas.LSPredictionItem] = []
+    api_predictions_for_ls: List[schemas.LSPredictionItem] = []
+
+    # 1. Get or Create Project
+    if not request_data.project:
+        raise HTTPException(status_code=400, detail="Project identifier (ID or name) is required.")
+
+    db_project = crud.get_or_create_project(db, project_identifier=request_data.project)
+    if not db_project:
+        raise HTTPException(status_code=404, detail=f"Project '{request_data.project}' not found and could not be created.")
+
+    if request_data.label_config and (not db_project.config_json or db_project.config_json != request_data.label_config) :
+        db_project.config_json = request_data.label_config
+        db.commit()
+        db.refresh(db_project)
+        print(f"Updated/set label_config for project ID {db_project.id}")
+
 
     for task in request_data.tasks:
-        image_url_or_path = task.data.get("image") # Assuming 'image' is the key for image path/URL in LS task data
+        image_path_key = "image"
+        image_url_or_path = getattr(task.data, image_path_key, None)
+
         if not image_url_or_path:
-            print(f"Task {task.id} missing image data. Skipping.")
-            api_predictions.append(schemas.LSPredictionItem(result=[])) # Empty result for this task
+            print(f"Task {task.id} missing image data under key '{image_path_key}'. Skipping.")
+            api_predictions_for_ls.append(schemas.LSPredictionItem(result=[]))
             continue
 
-        # --------------------------------------------------------------------
-        # TODO: Call the actual YOLO-UniOW model server
-        # This section will be replaced with a real HTTP call to the model server
-        # For now, using mocked response.
-        # --------------------------------------------------------------------
-        print(f"Simulating call to YOLO-UniOW server for task {task.id}, image: {image_url_or_path}")
-        # yolo_request_payload = {"image_path": image_url_or_path, "confidence_threshold": 0.25}
-        # try:
-        #     response = await client.post(settings.YOLO_UNIOW_SERVER_URL, json=yolo_request_payload, timeout=30.0)
-        #     response.raise_for_status()
-        #     yolo_results = response.json().get("predictions", []) # Assuming this is the structure from yolo_uniow_serve.py
-        # except httpx.RequestError as e:
-        #     print(f"Error calling YOLO-UniOW server for task {task.id}: {e}")
-        #     api_predictions.append(schemas.LSPredictionItem(result=[]))
-        #     continue
-        # except Exception as e: # Catch other potential errors like JSON decoding
-        #     print(f"Generic error processing task {task.id} with YOLO-UniOW server: {e}")
-        #     api_predictions.append(schemas.LSPredictionItem(result=[]))
-        #     continue
-        # --------------------------------------------------------------------
+        db_image = crud.get_or_create_image(db, image_path=image_url_or_path, project_id=db_project.id)
+        if not db_image:
+             print(f"Failed to get/create image record for {image_url_or_path}. Skipping task {task.id}.")
+             api_predictions_for_ls.append(schemas.LSPredictionItem(result=[]))
+             continue
 
-        # Call the YOLO-UniOW model server
         yolo_request_payload = {
-            "image_path": image_url_or_path, # This path must be accessible by the YOLO server
-                                             # (e.g., via a shared Docker volume mounted at the same path)
-            "confidence_threshold": 0.2 # Example threshold, could be configurable
+            "image_path": image_url_or_path,
+            "confidence_threshold": 0.2
         }
-        model_predictions = []
-        model_version_str = "yolo_uniow_mock_v0.1" # Default if server call fails
+        model_server_predictions = []
+        model_version_str = f"yolo_uniow_mock_v0.1"
 
         try:
-            print(f"Calling YOLO server at {settings.YOLO_UNIOW_SERVER_URL} for task {task.id}")
+            print(f"Calling YOLO server at {settings.YOLO_UNIOW_SERVER_URL} for task {task.id}, image_id {db_image.id}")
             response = await client.post(settings.YOLO_UNIOW_SERVER_URL, json=yolo_request_payload, timeout=30.0)
-            response.raise_for_status() # Raise an exception for bad status codes
+            response.raise_for_status()
 
             yolo_server_response = response.json()
-            model_predictions = yolo_server_response.get("predictions", [])
+            model_server_predictions = yolo_server_response.get("predictions", [])
             model_version_str = f"{yolo_server_response.get('model_name', 'yolo_uniow')}_v{yolo_server_response.get('version', 'unknown')}"
-            print(f"Received {len(model_predictions)} predictions from YOLO server for task {task.id}")
+            print(f"Received {len(model_server_predictions)} predictions from YOLO server for task {task.id}")
 
         except httpx.RequestError as e:
             print(f"Error calling YOLO-UniOW server for task {task.id} (image: {image_url_or_path}): {e}")
-            # Fallback to empty predictions for this task if model server call fails
-            api_predictions.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
+            api_predictions_for_ls.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
             continue
-        except Exception as e: # Catch other potential errors like JSON decoding or unexpected response structure
+        except Exception as e:
             print(f"Generic error processing task {task.id} with YOLO-UniOW server: {e}")
-            api_predictions.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
+            api_predictions_for_ls.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
             continue
 
+        annotations_to_create: List[schemas.AnnotationCreate] = []
+        if model_server_predictions:
+            for pred in model_server_predictions:
+                annotations_to_create.append(schemas.AnnotationCreate(
+                    label_name=pred.get("label", "unknown_label"),
+                    x_min=pred.get("x_min", 0.0),
+                    y_min=pred.get("y_min", 0.0),
+                    x_max=pred.get("x_max", 0.0),
+                    y_max=pred.get("y_max", 0.0),
+                    confidence_score=pred.get("score"),
+                    source_type=model_version_str,
+                    is_unknown=(pred.get("label", "").lower() == "unknown")
+                ))
 
-        # Determine from_name and to_name from label_config (simplified parsing)
-        # A more robust parsing of label_config XML might be needed for complex configs
-        from_name_found = "label" # Default or parsed
-        to_name_found = "image"   # Default or parsed
+        if annotations_to_create:
+            try:
+                crud.create_annotation_records(db, annotations_data=annotations_to_create, image_id=db_image.id, project_id=db_project.id)
+                print(f"Saved {len(annotations_to_create)} annotations to DB for image_id {db_image.id}")
+            except Exception as e:
+                print(f"Error saving annotations to DB for image_id {db_image.id}: {e}")
+
+        from_name_found, to_name_found = "label", "image"
         if request_data.label_config:
-            if "<RectangleLabels" in request_data.label_config:
-                # Simplistic way to get from_name for RectangleLabels
-                try:
-                    from_name_str = request_data.label_config.split('<RectangleLabels name="')[1].split('"')[0]
-                    from_name_found = from_name_str
-                    to_name_str = request_data.label_config.split('toName="')[1].split('"')[0]
-                    to_name_found = to_name_str
-                except IndexError:
-                    print("Could not parse from_name/to_name from label_config, using defaults.")
+            try:
+                if "<RectangleLabels" in request_data.label_config:
+                    from_name_found = request_data.label_config.split('<RectangleLabels name="')[1].split('"')[0]
+                    to_name_found = request_data.label_config.split('toName="')[1].split('"')[0]
+            except IndexError:
+                print("Could not parse from_name/to_name from label_config, using defaults.")
 
-
-        # Format model_predictions (from YOLO server) into Label Studio prediction format
         ls_results_for_task: List[schemas.LSAnnotationResultItem] = []
-        if model_predictions: # Ensure there are predictions to process
-            for yolo_pred in model_predictions:
-                # yolo_pred is now expected to be a dict from the JSON response
-                # e.g. {'x_min': 50.0, 'y_min': 50.0, 'x_max': 150.0, 'y_max': 150.0, 'label': 'mock_car', 'score': 0.92}
+        if model_server_predictions:
+            for pred in model_server_predictions:
                 ls_results_for_task.append(
                     schemas.LSAnnotationResultItem(
                         from_name=from_name_found,
                         to_name=to_name_found,
                         type="rectanglelabels",
                         value=schemas.LSAnnotationResultItemValue(
-                            rectanglelabels=[yolo_pred.get("label", "unknown_label")], # Use .get for safety
-                            x=yolo_pred.get("x_min", 0.0),
-                            y=yolo_pred.get("y_min", 0.0),
-                            width=(yolo_pred.get("x_max", 0.0) - yolo_pred.get("x_min", 0.0)),
-                            height=(yolo_pred.get("y_max", 0.0) - yolo_pred.get("y_min", 0.0)),
+                            rectanglelabels=[pred.get("label", "unknown_label")],
+                            x=pred.get("x_min", 0.0),
+                            y=pred.get("y_min", 0.0),
+                            width=(pred.get("x_max", 0.0) - pred.get("x_min", 0.0)),
+                            height=(pred.get("y_max", 0.0) - pred.get("y_min", 0.0)),
                         ),
-                        score=yolo_pred.get("score", 0.0)
+                        score=pred.get("score")
                     )
                 )
 
-        api_predictions.append(schemas.LSPredictionItem(
+        api_predictions_for_ls.append(schemas.LSPredictionItem(
             result=ls_results_for_task,
             score=max((res.score for res in ls_results_for_task if res.score is not None), default=0) if ls_results_for_task else 0,
             model_version=model_version_str
         ))
 
-    return api_predictions
+    return api_predictions_for_ls
 
 @router.post("/generate_object",
-             response_model=schemas.ObjectGenerationResponse, # Use Pydantic for response
+             response_model=schemas.ObjectGenerationResponse,
              summary="Generate Object in Image (GLIGEN)")
 async def generate_object(
-    request_data: schemas.ObjectGenerationRequest, # Use Pydantic for request
-    client: httpx.AsyncClient = Depends(get_http_client)
+    request_data: schemas.ObjectGenerationRequest,
+    client: httpx.AsyncClient = Depends(get_http_client),
+    db: Session = Depends(database.get_db)
 ) -> schemas.ObjectGenerationResponse:
     """
-    Endpoint to generate an object in an image using GLIGEN.
-    Expects: background image path, target bounding box, text prompt, project ID.
-    Returns: path to new image and its annotation.
+    Endpoint to generate an object in an image (using a mock GLIGEN call).
+    Saves metadata about the generated image and its annotation to the database.
     """
-    print(f"Received /generate_object request for project {request_data.project_id} on image {request_data.image_path}")
+    print(f"Received /generate_object request for project {request_data.project_id}")
 
-    # TODO:
-    # 1. Construct payload for GLIGEN model server
-    #    gligen_payload = {
-    #        "image_path": request_data.image_path, # This path needs to be accessible by GLIGEN server
-    #        "target_bbox": request_data.target_bbox,
-    #        "text_prompt": request_data.text_prompt
-    #    }
-    # 2. Call GLIGEN model service using 'client' (httpx.AsyncClient)
-    #    response = await client.post(settings.GLIGEN_SERVER_URL, json=gligen_payload, timeout=120.0) # Long timeout for generation
-    #    response.raise_for_status()
-    #    gligen_result = response.json() # e.g., {"generated_image_path_on_server": "..."}
-    # 3. Process result:
-    #    - If GLIGEN server saves the image, determine its path relative to IMAGE_STORAGE_BASE_PATH.
-    #    - Or, if it returns image bytes, save it here.
-    #    - Create an annotation entry in the database for the new object.
+    db_project = crud.get_project(db, project_id=request_data.project_id)
+    if not db_project:
+        raise HTTPException(status_code=404, detail=f"Project with ID {request_data.project_id} not found.")
 
-    # Mocked response for now
-    mock_new_image_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/project_{request_data.project_id}/generated/gligen_mock_{request_data.image_path.split('/')[-1]}"
-    mock_annotation = schemas.Annotation(
-        image_id=-1, # Placeholder, would come from DB insert of new image
-        label_id=-1, # Placeholder, would come from DB lookup of label by name (derived from prompt or new label)
+    source_db_image_id: Optional[int] = None
+    source_image_width: Optional[int] = None
+    source_image_height: Optional[int] = None
+    if request_data.source_image_path:
+        source_db_image = crud.get_or_create_image(db, image_path=request_data.source_image_path, project_id=db_project.id)
+        source_db_image_id = source_db_image.id
+        source_image_width = source_db_image.width
+        source_image_height = source_db_image.height
+        print(f"Using source image ID: {source_db_image_id} from path: {request_data.source_image_path}")
+
+    base_filename = request_data.source_image_path.split('/')[-1] if request_data.source_image_path else "from_scratch"
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    mock_generated_filename = f"gligen_mock_{timestamp}_{base_filename}.jpg"
+
+    # Path where the generated image would be "saved" by the application logic
+    # This is relative to the IMAGE_STORAGE_BASE_PATH
+    generated_image_relative_path = f"project_{db_project.id}/generated/{mock_generated_filename}"
+    # The actual generated_file_path to store in DB includes the base path for consistency if needed elsewhere,
+    # but often it's better to store relative paths and prepend base path on use.
+    # For this example, let's store the path as known from within the Docker volume context.
+    db_generated_file_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/{generated_image_relative_path}"
+
+    print(f"Mocking GLIGEN call. Prompt: '{request_data.text_prompt}'. Label: '{request_data.label_name_for_generated_object}'")
+    print(f"Mock generated image path (for DB): {db_generated_file_path}")
+    # TODO: (Actual GLIGEN call)
+    # gligen_payload = { "source_image_path": request_data.source_image_path,
+    #                    "target_bbox": request_data.target_bbox,
+    #                    "text_prompt": request_data.text_prompt }
+    # response = await client.post(settings.GLIGEN_SERVER_URL, json=gligen_payload, timeout=120.0)
+    # response.raise_for_status()
+    # gligen_server_response = response.json()
+    # actual_generated_image_path_from_gligen = gligen_server_response.get("output_image_path")
+    # db_generated_file_path = actual_generated_image_path_from_gligen # Adjust based on where GLIGEN server saves it
+
+    generation_params = {
+        "prompt": request_data.text_prompt,
+        "target_bbox": request_data.target_bbox,
+        "model_used": "GLIGEN_mock_v0.1",
+        "label_name_for_generated_object": request_data.label_name_for_generated_object
+    }
+    image_create_data = schemas.ImageCreate(
+        project_id=db_project.id,
+        original_file_path=request_data.source_image_path, # Background image
+        generated_file_path=db_generated_file_path,       # New image with object
+        source_image_id=source_db_image_id,
+        generation_params_json=json.dumps(generation_params),
+        width=source_image_width, # Assume generated image has same dimensions as source for now
+        height=source_image_height
+    )
+    new_db_image = crud.create_image_record(db, image=image_create_data)
+    print(f"Created new image record in DB with ID: {new_db_image.id} at path {new_db_image.generated_file_path}")
+
+    db_label = crud.get_or_create_label(db, label_name=request_data.label_name_for_generated_object, project_id=db_project.id)
+    print(f"Using label ID: {db_label.id} for label name: '{request_data.label_name_for_generated_object}'")
+
+    annotation_create_data = schemas.AnnotationCreate(
+        label_name=db_label.name,
         x_min=request_data.target_bbox[0],
         y_min=request_data.target_bbox[1],
         x_max=request_data.target_bbox[2],
         y_max=request_data.target_bbox[3],
-        source_type="gligen_generated"
+        source_type=generation_params["model_used"],
+        confidence_score=1.0
+    )
+    created_db_annotations = crud.create_annotation_records(
+        db,
+        annotations_data=[annotation_create_data],
+        image_id=new_db_image.id,
+        project_id=db_project.id
     )
 
-    print(f"Mocked GLIGEN generation. Output path: {mock_new_image_path}")
+    if not created_db_annotations:
+        raise HTTPException(status_code=500, detail="Failed to create annotation record for the generated object.")
+
+    db_annotation_created = created_db_annotations[0]
+    print(f"Created annotation record in DB with ID: {db_annotation_created.id}")
+
+    response_annotation = schemas.Annotation.from_orm(db_annotation_created)
+
     return schemas.ObjectGenerationResponse(
-        new_image_path=mock_new_image_path,
-        annotation=mock_annotation
+        new_image_path=new_db_image.generated_file_path,
+        annotation=response_annotation
     )
 
 @router.post("/edit_scene",
@@ -189,7 +255,8 @@ async def generate_object(
              summary="Edit Scene with Inpainting (ControlNet)")
 async def edit_scene(
     request_data: schemas.SceneEditRequest,
-    client: httpx.AsyncClient = Depends(get_http_client)
+    client: httpx.AsyncClient = Depends(get_http_client),
+    db: Session = Depends(database.get_db)
 ) -> schemas.SceneEditResponse:
     """
     Endpoint to edit a scene using ControlNet for inpainting.
@@ -197,26 +264,44 @@ async def edit_scene(
     Returns: path to edited image.
     """
     print(f"Received /edit_scene request for project {request_data.project_id} on image {request_data.image_path}")
+
+    db_project = crud.get_project(db, project_id=request_data.project_id)
+    if not db_project:
+        raise HTTPException(status_code=404, detail=f"Project {request_data.project_id} not found.")
+
     # TODO: Implement call to ControlNet model service
     # controlnet_payload = { ... }
     # response = await client.post(settings.CONTROLNET_SERVER_URL, json=controlnet_payload, timeout=180.0)
     # response.raise_for_status()
     # controlnet_result = response.json()
-    # 1. Save the edited image (returned as path or bytes by ControlNet server)
-    # 2. Store metadata in DB (e.g., link to original image, generation params)
+    # 1. Save the edited image (returned as path or bytes by ControlNet server) to a new file path.
+    #    This new path would be similar to how generated_file_path is constructed for GLIGEN.
+    # 2. Create a new Image record in DB for this edited image:
+    #    - original_file_path = request_data.image_path (the image that was edited)
+    #    - generated_file_path = path of the new edited image
+    #    - source_image_id = ID of the original image that was edited
+    #    - generation_params_json = { "prompt": request_data.text_prompt, "mask_info": "...", "model_used": "ControlNet_mock_v0.1" }
+    #    - Potentially, new annotations might be relevant if objects changed class or new ones appeared. This is complex.
+    #      For now, just saving the new image might be sufficient for MVP.
 
     # Mocked response
-    mock_edited_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/project_{request_data.project_id}/generated/controlnet_mock_{request_data.image_path.split('/')[-1]}"
-    print(f"Mocked ControlNet edit. Output path: {mock_edited_path}")
+    base_filename = request_data.image_path.split('/')[-1]
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    mock_edited_filename = f"controlnet_mock_{timestamp}_{base_filename}.jpg"
+    edited_image_relative_path = f"project_{db_project.id}/generated/{mock_edited_filename}"
+    db_edited_file_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/{edited_image_relative_path}"
+
+    print(f"Mocked ControlNet edit. Output path (for DB): {db_edited_file_path}")
     # This response should ideally include more info, like DB record ID of the new image.
-    return schemas.SceneEditResponse(edited_image_path=mock_edited_path)
+    return schemas.SceneEditResponse(edited_image_path=db_edited_file_path)
 
 @router.post("/suggest_prompts",
              response_model=schemas.PromptSuggestionResponse,
              summary="Suggest Prompts (InternVL2)")
 async def suggest_prompts(
     request_data: schemas.PromptSuggestionRequest,
-    client: httpx.AsyncClient = Depends(get_http_client)
+    client: httpx.AsyncClient = Depends(get_http_client),
+    db: Session = Depends(database.get_db) # Added DB session if context from DB is needed
 ) -> schemas.PromptSuggestionResponse:
     """
     Endpoint to get prompt suggestions from InternVL2.
@@ -224,8 +309,14 @@ async def suggest_prompts(
     Returns: list of suggested prompts.
     """
     print(f"Received /suggest_prompts request for keyword: {request_data.base_keyword}")
+    if request_data.project_id:
+        db_project = crud.get_project(db, project_id=request_data.project_id)
+        if not db_project:
+            print(f"Warning: Project ID {request_data.project_id} provided for prompt suggestion but not found.")
+        # else: use db_project.name or description to add context to prompt for InternVL2
+
     # TODO: Implement call to InternVL2 model service
-    # internvl2_payload = {"keyword": request_data.base_keyword, "context": "..." }
+    # internvl2_payload = {"keyword": request_data.base_keyword, "context": "..." } # Add project context if available
     # response = await client.post(settings.INTERNVL2_SERVER_URL, json=internvl2_payload, timeout=60.0)
     # response.raise_for_status()
     # suggestions_result = response.json() # e.g., {"suggestions": []}

--- a/backend_api/app/api/endpoints.py
+++ b/backend_api/app/api/endpoints.py
@@ -57,12 +57,35 @@ async def predict_annotations(
         #     continue
         # --------------------------------------------------------------------
 
-        # Mocked YOLO results for demonstration
-        mock_yolo_results = [
-            {"x_min": 10.0, "y_min": 20.0, "x_max": 40.0, "y_max": 60.0, "label": "car", "score": 0.95},
-            {"x_min": 50.0, "y_min": 60.0, "x_max": 80.0, "y_max": 90.0, "label": "person", "score": 0.88},
-            {"x_min": 100.0, "y_min": 100.0, "x_max": 120.0, "y_max": 120.0, "label": "unknown", "score": 0.65}, # Example of 'unknown'
-        ]
+        # Call the YOLO-UniOW model server
+        yolo_request_payload = {
+            "image_path": image_url_or_path, # This path must be accessible by the YOLO server
+                                             # (e.g., via a shared Docker volume mounted at the same path)
+            "confidence_threshold": 0.2 # Example threshold, could be configurable
+        }
+        model_predictions = []
+        model_version_str = "yolo_uniow_mock_v0.1" # Default if server call fails
+
+        try:
+            print(f"Calling YOLO server at {settings.YOLO_UNIOW_SERVER_URL} for task {task.id}")
+            response = await client.post(settings.YOLO_UNIOW_SERVER_URL, json=yolo_request_payload, timeout=30.0)
+            response.raise_for_status() # Raise an exception for bad status codes
+
+            yolo_server_response = response.json()
+            model_predictions = yolo_server_response.get("predictions", [])
+            model_version_str = f"{yolo_server_response.get('model_name', 'yolo_uniow')}_v{yolo_server_response.get('version', 'unknown')}"
+            print(f"Received {len(model_predictions)} predictions from YOLO server for task {task.id}")
+
+        except httpx.RequestError as e:
+            print(f"Error calling YOLO-UniOW server for task {task.id} (image: {image_url_or_path}): {e}")
+            # Fallback to empty predictions for this task if model server call fails
+            api_predictions.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
+            continue
+        except Exception as e: # Catch other potential errors like JSON decoding or unexpected response structure
+            print(f"Generic error processing task {task.id} with YOLO-UniOW server: {e}")
+            api_predictions.append(schemas.LSPredictionItem(result=[], model_version=model_version_str))
+            continue
+
 
         # Determine from_name and to_name from label_config (simplified parsing)
         # A more robust parsing of label_config XML might be needed for complex configs
@@ -80,29 +103,32 @@ async def predict_annotations(
                     print("Could not parse from_name/to_name from label_config, using defaults.")
 
 
-        # Format mock_yolo_results into Label Studio prediction format
+        # Format model_predictions (from YOLO server) into Label Studio prediction format
         ls_results_for_task: List[schemas.LSAnnotationResultItem] = []
-        for yolo_pred in mock_yolo_results:
-            ls_results_for_task.append(
-                schemas.LSAnnotationResultItem(
-                    from_name=from_name_found,
-                    to_name=to_name_found,
-                    type="rectanglelabels", # Assuming detection model provides rectangles
-                    value=schemas.LSAnnotationResultItemValue(
-                        rectanglelabels=[yolo_pred["label"]],
-                        x=yolo_pred["x_min"],
-                        y=yolo_pred["y_min"],
-                        width=(yolo_pred["x_max"] - yolo_pred["x_min"]),
-                        height=(yolo_pred["y_max"] - yolo_pred["y_min"]),
-                    ),
-                    score=yolo_pred["score"]
+        if model_predictions: # Ensure there are predictions to process
+            for yolo_pred in model_predictions:
+                # yolo_pred is now expected to be a dict from the JSON response
+                # e.g. {'x_min': 50.0, 'y_min': 50.0, 'x_max': 150.0, 'y_max': 150.0, 'label': 'mock_car', 'score': 0.92}
+                ls_results_for_task.append(
+                    schemas.LSAnnotationResultItem(
+                        from_name=from_name_found,
+                        to_name=to_name_found,
+                        type="rectanglelabels",
+                        value=schemas.LSAnnotationResultItemValue(
+                            rectanglelabels=[yolo_pred.get("label", "unknown_label")], # Use .get for safety
+                            x=yolo_pred.get("x_min", 0.0),
+                            y=yolo_pred.get("y_min", 0.0),
+                            width=(yolo_pred.get("x_max", 0.0) - yolo_pred.get("x_min", 0.0)),
+                            height=(yolo_pred.get("y_max", 0.0) - yolo_pred.get("y_min", 0.0)),
+                        ),
+                        score=yolo_pred.get("score", 0.0)
+                    )
                 )
-            )
 
         api_predictions.append(schemas.LSPredictionItem(
             result=ls_results_for_task,
-            score=max((res.score for res in ls_results_for_task if res.score is not None), default=0), # Overall task score
-            model_version=f"mock_yolo_uniow_v0.1_task_{task.id}" # Example model version
+            score=max((res.score for res in ls_results_for_task if res.score is not None), default=0) if ls_results_for_task else 0,
+            model_version=model_version_str
         ))
 
     return api_predictions
@@ -169,9 +195,17 @@ async def edit_scene(
     """
     print(f"Received /edit_scene request for project {request_data.project_id} on image {request_data.image_path}")
     # TODO: Implement call to ControlNet model service
+    # controlnet_payload = { ... }
+    # response = await client.post(settings.CONTROLNET_SERVER_URL, json=controlnet_payload, timeout=180.0)
+    # response.raise_for_status()
+    # controlnet_result = response.json()
+    # 1. Save the edited image (returned as path or bytes by ControlNet server)
+    # 2. Store metadata in DB (e.g., link to original image, generation params)
+
     # Mocked response
     mock_edited_path = f"{settings.IMAGE_STORAGE_BASE_PATH}/project_{request_data.project_id}/generated/controlnet_mock_{request_data.image_path.split('/')[-1]}"
     print(f"Mocked ControlNet edit. Output path: {mock_edited_path}")
+    # This response should ideally include more info, like DB record ID of the new image.
     return schemas.SceneEditResponse(edited_image_path=mock_edited_path)
 
 @router.post("/suggest_prompts",
@@ -188,12 +222,18 @@ async def suggest_prompts(
     """
     print(f"Received /suggest_prompts request for keyword: {request_data.base_keyword}")
     # TODO: Implement call to InternVL2 model service
+    # internvl2_payload = {"keyword": request_data.base_keyword, "context": "..." }
+    # response = await client.post(settings.INTERNVL2_SERVER_URL, json=internvl2_payload, timeout=60.0)
+    # response.raise_for_status()
+    # suggestions_result = response.json() # e.g., {"suggestions": []}
+
     # Mocked response
     mock_suggestions = [
-        f"A high-quality, photorealistic image of a {request_data.base_keyword} in a sunlit environment.",
-        f"Close-up studio shot of a {request_data.base_keyword}, highly detailed.",
-        f"An artistic rendering of a {request_data.base_keyword} in a surreal landscape."
+        f"A high-quality, photorealistic image of a {request_data.base_keyword} in a sunlit environment, 4k, detailed.",
+        f"Close-up studio shot of a {request_data.base_keyword}, highly detailed, dramatic lighting.",
+        f"An artistic rendering of a {request_data.base_keyword} in a surreal landscape, concept art."
     ]
+    print(f"Mocked InternVL2 suggestions for '{request_data.base_keyword}'.")
     return schemas.PromptSuggestionResponse(suggestions=mock_suggestions)
 
 @router.post("/setup", summary="ML Backend Setup/Health Check (Optional)")

--- a/backend_api/app/core/config.py
+++ b/backend_api/app/core/config.py
@@ -1,0 +1,37 @@
+```python
+from pydantic_settings import BaseSettings
+from functools import lru_cache
+
+class Settings(BaseSettings):
+    APP_NAME: str = "Agile AI Vision Backend API"
+    DEBUG: bool = False
+
+    # Database settings
+    DATABASE_URL: str = "sqlite:///./data/database/metadata.db" # Default path, can be overridden by env var
+
+    # File storage settings
+    IMAGE_STORAGE_BASE_PATH: str = "./data/images" # Default path
+
+    # Model Server URLs (examples, actual URLs will depend on deployment)
+    YOLO_UNIOW_SERVER_URL: str = "http://yolo_uniow_model_server:8001/infer" # Assuming port 8001 for yolo server
+    GROUNDING_DINO_SERVER_URL: str = "http://grounding_dino_model_server:8002/infer"
+    GLIGEN_SERVER_URL: str = "http://gligen_model_server:8003/generate"
+    CONTROLNET_SERVER_URL: str = "http://controlnet_model_server:8004/edit"
+    INTERNVL2_SERVER_URL: str = "http://internvl2_model_server:8005/suggest"
+
+    class Config:
+        env_file = ".env" # Load environment variables from .env file if it exists
+        env_file_encoding = 'utf-8'
+
+@lru_cache()
+def get_settings():
+    return Settings()
+
+settings = get_settings()
+
+if __name__ == "__main__":
+    # Print settings to verify
+    print("Current Settings:")
+    for key, value in settings.dict().items():
+        print(f"{key}: {value}")
+```

--- a/backend_api/app/db/crud.py
+++ b/backend_api/app/db/crud.py
@@ -1,0 +1,105 @@
+```python
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from . import models as db_models # To avoid confusion with Pydantic schemas
+from ..models import schemas # Pydantic schemas for request/response data validation
+
+# --- Project CRUD ---
+def get_project(db: Session, project_id: int) -> Optional[db_models.Project]:
+    return db.query(db_models.Project).filter(db_models.Project.id == project_id).first()
+
+def get_project_by_name(db: Session, project_name: str) -> Optional[db_models.Project]:
+    return db.query(db_models.Project).filter(db_models.Project.name == project_name).first()
+
+def create_project(db: Session, project: schemas.Project) -> db_models.Project:
+    # Assuming schemas.Project is used for creation and has compatible fields.
+    # You might want a specific schemas.ProjectCreate if fields differ.
+    db_project = db_models.Project(
+        name=project.project_name, # Assuming project_name in Pydantic schema
+        description=project.description,
+        config_json=project.config_json
+    )
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+# --- Label CRUD ---
+def get_label_by_name(db: Session, label_name: str, project_id: int) -> Optional[db_models.Label]:
+    return db.query(db_models.Label).filter(db_models.Label.name == label_name, db_models.Label.project_id == project_id).first()
+
+def get_or_create_label(db: Session, label_name: str, project_id: int, color_hex: Optional[str] = None) -> db_models.Label:
+    db_label = get_label_by_name(db, label_name=label_name, project_id=project_id)
+    if db_label:
+        return db_label
+    db_label = db_models.Label(name=label_name, project_id=project_id, color_hex=color_hex)
+    db.add(db_label)
+    db.commit()
+    db.refresh(db_label)
+    return db_label
+
+# --- Image CRUD ---
+def create_image_record(db: Session, image: schemas.Image, project_id: int) -> db_models.Image:
+    # Assuming schemas.Image is used for creation.
+    # You might want a specific schemas.ImageCreate.
+    db_image = db_models.Image(
+        project_id=project_id,
+        original_file_path=image.original_file_path,
+        generated_file_path=image.generated_file_path,
+        width=image.width,
+        height=image.height,
+        source_image_id=image.source_image_id,
+        generation_params_json=image.generation_params_json
+    )
+    db.add(db_image)
+    db.commit()
+    db.refresh(db_image)
+    return db_image
+
+def get_image(db: Session, image_id: int) -> Optional[db_models.Image]:
+    return db.query(db_models.Image).filter(db_models.Image.id == image_id).first()
+
+# --- Annotation CRUD ---
+def create_annotation_records(db: Session, annotations: List[schemas.Annotation], image_id: int) -> List[db_models.Annotation]:
+    # Assuming schemas.Annotation is used for creation.
+    # You might want a specific schemas.AnnotationCreate.
+    db_annotations = []
+    for ann_data in annotations:
+        # Ensure label_id is present or fetch/create it
+        # This part depends on how label_id is handled in schemas.Annotation
+        # If ann_data.label_id is not directly provided, you'd fetch it using get_or_create_label
+        # For now, assuming ann_data.label_id is correctly populated or handled upstream.
+        if ann_data.label_id is None: # Or some other check if label name is provided instead
+            raise ValueError("label_id must be provided for creating an annotation.")
+
+        db_ann = db_models.Annotation(
+            image_id=image_id,
+            label_id=ann_data.label_id, # This assumes schemas.Annotation has label_id
+            x_min=ann_data.x_min,
+            y_min=ann_data.y_min,
+            x_max=ann_data.x_max,
+            y_max=ann_data.y_max,
+            confidence_score=ann_data.confidence_score,
+            source_type=ann_data.source_type,
+            is_unknown=ann_data.is_unknown
+        )
+        db.add(db_ann)
+        db_annotations.append(db_ann)
+    db.commit()
+    for db_ann in db_annotations: # Refresh each object to get IDs, etc.
+        db.refresh(db_ann)
+    return db_annotations
+
+def get_annotations_for_image(db: Session, image_id: int) -> List[db_models.Annotation]:
+    return db.query(db_models.Annotation).filter(db_models.Annotation.image_id == image_id).all()
+
+# Placeholder for Pydantic create schemas if they differ significantly from main schemas
+# For example:
+# class ProjectCreate(schemas.ProjectBase): # Assuming ProjectBase has common fields
+#     pass
+# class ImageCreate(schemas.ImageBase):
+#     pass
+# class AnnotationCreate(schemas.AnnotationBase):
+#     label_name: Optional[str] = None # Could pass label name instead of id
+```

--- a/backend_api/app/db/crud.py
+++ b/backend_api/app/db/crud.py
@@ -1,9 +1,10 @@
 ```python
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from typing import List, Optional
 
-from . import models as db_models # To avoid confusion with Pydantic schemas
-from ..models import schemas # Pydantic schemas for request/response data validation
+from . import models as db_models
+from ..models import schemas
 
 # --- Project CRUD ---
 def get_project(db: Session, project_id: int) -> Optional[db_models.Project]:
@@ -12,39 +13,88 @@ def get_project(db: Session, project_id: int) -> Optional[db_models.Project]:
 def get_project_by_name(db: Session, project_name: str) -> Optional[db_models.Project]:
     return db.query(db_models.Project).filter(db_models.Project.name == project_name).first()
 
-def create_project(db: Session, project: schemas.Project) -> db_models.Project:
-    # Assuming schemas.Project is used for creation and has compatible fields.
-    # You might want a specific schemas.ProjectCreate if fields differ.
+def create_project(db: Session, project: schemas.ProjectCreate) -> db_models.Project:
     db_project = db_models.Project(
-        name=project.project_name, # Assuming project_name in Pydantic schema
+        name=project.name,
         description=project.description,
         config_json=project.config_json
     )
     db.add(db_project)
-    db.commit()
-    db.refresh(db_project)
+    try:
+        db.commit()
+        db.refresh(db_project)
+    except IntegrityError: # Handles unique constraint violation for name
+        db.rollback()
+        existing_project = get_project_by_name(db, project.name)
+        if existing_project:
+            return existing_project # Or raise an error, depending on desired behavior
+        else: # Should not happen if IntegrityError was due to name
+            raise
     return db_project
 
-# --- Label CRUD ---
-def get_label_by_name(db: Session, label_name: str, project_id: int) -> Optional[db_models.Label]:
-    return db.query(db_models.Label).filter(db_models.Label.name == label_name, db_models.Label.project_id == project_id).first()
+def get_or_create_project(db: Session, project_identifier: str) -> db_models.Project:
+    """Gets a project by ID (if numeric string) or name, or creates it if it doesn't exist by name."""
+    project_id = None
+    if project_identifier.isdigit():
+        project_id = int(project_identifier)
+        db_project = get_project(db, project_id)
+        if db_project:
+            return db_project
 
-def get_or_create_label(db: Session, label_name: str, project_id: int, color_hex: Optional[str] = None) -> db_models.Label:
-    db_label = get_label_by_name(db, label_name=label_name, project_id=project_id)
-    if db_label:
-        return db_label
-    db_label = db_models.Label(name=label_name, project_id=project_id, color_hex=color_hex)
+    # If not found by ID or identifier is not numeric, try by name
+    db_project = get_project_by_name(db, project_name=project_identifier)
+    if db_project:
+        return db_project
+
+    # If still not found, create it (assuming identifier was a name)
+    # Use default description and config if not provided.
+    print(f"Project '{project_identifier}' not found, creating new project.")
+    return create_project(db, schemas.ProjectCreate(name=project_identifier))
+
+
+# --- Label CRUD ---
+def get_label_by_name_and_project(db: Session, label_name: str, project_id: int) -> Optional[db_models.Label]:
+    return db.query(db_models.Label).filter(
+        db_models.Label.name == label_name,
+        db_models.Label.project_id == project_id
+    ).first()
+
+def create_label(db: Session, label: schemas.LabelCreate) -> db_models.Label:
+    db_label = db_models.Label(
+        name=label.name,
+        project_id=label.project_id,
+        color_hex=label.color_hex
+    )
     db.add(db_label)
-    db.commit()
-    db.refresh(db_label)
+    try:
+        db.commit()
+        db.refresh(db_label)
+    except IntegrityError: # Handles unique constraint (project_id, name)
+        db.rollback()
+        existing_label = get_label_by_name_and_project(db, label.name, label.project_id)
+        if existing_label:
+            return existing_label
+        else:
+            raise
     return db_label
 
+def get_or_create_label(db: Session, label_name: str, project_id: int, color_hex: Optional[str] = None) -> db_models.Label:
+    db_label = get_label_by_name_and_project(db, label_name=label_name, project_id=project_id)
+    if db_label:
+        return db_label
+
+    return create_label(db, schemas.LabelCreate(name=label_name, project_id=project_id, color_hex=color_hex))
+
 # --- Image CRUD ---
-def create_image_record(db: Session, image: schemas.Image, project_id: int) -> db_models.Image:
-    # Assuming schemas.Image is used for creation.
-    # You might want a specific schemas.ImageCreate.
+def get_image_by_path_and_project(db: Session, image_path: str, project_id: int) -> Optional[db_models.Image]:
+    return db.query(db_models.Image).filter(
+        db_models.Image.original_file_path == image_path,
+        db_models.Image.project_id == project_id
+    ).first()
+
+def create_image_record(db: Session, image: schemas.ImageCreate) -> db_models.Image:
     db_image = db_models.Image(
-        project_id=project_id,
+        project_id=image.project_id,
         original_file_path=image.original_file_path,
         generated_file_path=image.generated_file_path,
         width=image.width,
@@ -57,25 +107,38 @@ def create_image_record(db: Session, image: schemas.Image, project_id: int) -> d
     db.refresh(db_image)
     return db_image
 
+def get_or_create_image(db: Session, image_path: str, project_id: int, width: Optional[int]=None, height: Optional[int]=None) -> db_models.Image:
+    db_image = get_image_by_path_and_project(db, image_path=image_path, project_id=project_id)
+    if db_image:
+        # Optionally update width/height if not set and provided now
+        if width and not db_image.width: db_image.width = width
+        if height and not db_image.height: db_image.height = height
+        if db.is_modified(db_image):
+            db.commit()
+            db.refresh(db_image)
+        return db_image
+
+    return create_image_record(db, schemas.ImageCreate(
+        project_id=project_id,
+        original_file_path=image_path,
+        width=width,
+        height=height
+    ))
+
+
 def get_image(db: Session, image_id: int) -> Optional[db_models.Image]:
     return db.query(db_models.Image).filter(db_models.Image.id == image_id).first()
 
 # --- Annotation CRUD ---
-def create_annotation_records(db: Session, annotations: List[schemas.Annotation], image_id: int) -> List[db_models.Annotation]:
-    # Assuming schemas.Annotation is used for creation.
-    # You might want a specific schemas.AnnotationCreate.
+def create_annotation_records(db: Session, annotations_data: List[schemas.AnnotationCreate], image_id: int, project_id: int) -> List[db_models.Annotation]:
     db_annotations = []
-    for ann_data in annotations:
-        # Ensure label_id is present or fetch/create it
-        # This part depends on how label_id is handled in schemas.Annotation
-        # If ann_data.label_id is not directly provided, you'd fetch it using get_or_create_label
-        # For now, assuming ann_data.label_id is correctly populated or handled upstream.
-        if ann_data.label_id is None: # Or some other check if label name is provided instead
-            raise ValueError("label_id must be provided for creating an annotation.")
+    for ann_data in annotations_data:
+        # Get or create the label for this annotation
+        db_label = get_or_create_label(db, label_name=ann_data.label_name, project_id=project_id)
 
         db_ann = db_models.Annotation(
             image_id=image_id,
-            label_id=ann_data.label_id, # This assumes schemas.Annotation has label_id
+            label_id=db_label.id, # Use the ID from the fetched/created label
             x_min=ann_data.x_min,
             y_min=ann_data.y_min,
             x_max=ann_data.x_max,
@@ -86,20 +149,13 @@ def create_annotation_records(db: Session, annotations: List[schemas.Annotation]
         )
         db.add(db_ann)
         db_annotations.append(db_ann)
-    db.commit()
-    for db_ann in db_annotations: # Refresh each object to get IDs, etc.
-        db.refresh(db_ann)
+
+    if db_annotations: # Only commit if there are annotations to add
+        db.commit()
+        for db_ann in db_annotations: # Refresh each object to get IDs, etc.
+            db.refresh(db_ann)
     return db_annotations
 
 def get_annotations_for_image(db: Session, image_id: int) -> List[db_models.Annotation]:
     return db.query(db_models.Annotation).filter(db_models.Annotation.image_id == image_id).all()
-
-# Placeholder for Pydantic create schemas if they differ significantly from main schemas
-# For example:
-# class ProjectCreate(schemas.ProjectBase): # Assuming ProjectBase has common fields
-#     pass
-# class ImageCreate(schemas.ImageBase):
-#     pass
-# class AnnotationCreate(schemas.AnnotationBase):
-#     label_name: Optional[str] = None # Could pass label name instead of id
 ```

--- a/backend_api/app/db/database.py
+++ b/backend_api/app/db/database.py
@@ -1,0 +1,52 @@
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from ..core.config import settings # Get DATABASE_URL from settings
+
+# Create a SQLAlchemy engine
+# For SQLite, connect_args is needed to enable foreign key support if not enabled by default in some Python versions
+engine_args = {}
+if settings.DATABASE_URL.startswith("sqlite"):
+    engine_args["connect_args"] = {"check_same_thread": False} # Required for SQLite with FastAPI
+
+engine = create_engine(
+    settings.DATABASE_URL, **engine_args
+)
+
+# Create a SessionLocal class. Instances of this class will be actual database sessions.
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Create a Base class. Our ORM models will inherit from this class.
+Base = declarative_base()
+
+# Dependency to get DB session in FastAPI path operations
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def create_db_and_tables():
+    """
+    Creates all database tables defined by models inheriting from Base.
+    This should be called once on application startup.
+    """
+    try:
+        Base.metadata.create_all(bind=engine)
+        print("Database tables created successfully (if they didn't exist).")
+    except Exception as e:
+        print(f"Error creating database tables: {e}")
+        # Depending on the application, you might want to handle this more gracefully
+        # or ensure the application doesn't start if DB setup fails.
+
+if __name__ == "__main__":
+    # For manual table creation or testing
+    print(f"Creating database tables for URL: {settings.DATABASE_URL}")
+    # Note: Models need to be imported for Base.metadata to be populated before calling create_all
+    # from . import models # Assuming models.py is in the same directory or adjust import
+    # create_db_and_tables()
+    print("If you ran this directly, ensure your ORM models (e.g., in db/models.py) are imported before create_db_and_tables is called.")
+```

--- a/backend_api/app/db/models.py
+++ b/backend_api/app/db/models.py
@@ -1,0 +1,84 @@
+```python
+from sqlalchemy import Column, Integer, String, Float, Boolean, DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func # For server-side default timestamp
+
+from .database import Base # Import Base from database.py
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    name = Column(String, nullable=False, unique=True, index=True)
+    description = Column(Text, nullable=True)
+    config_json = Column(Text, nullable=True) # For Label Studio labeling config or other settings
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    images = relationship("Image", back_populates="project")
+    labels = relationship("Label", back_populates="project")
+
+
+class Image(Base):
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
+
+    original_file_path = Column(String, nullable=False) # Path in the local FS or object storage key
+    generated_file_path = Column(String, nullable=True) # Path if this is an AI-generated image
+
+    width = Column(Integer, nullable=True)
+    height = Column(Integer, nullable=True)
+
+    uploaded_at = Column(DateTime(timezone=True), server_default=func.now())
+    # If generated, links to the base image used for generation
+    source_image_id = Column(Integer, ForeignKey("images.id"), nullable=True)
+    generation_params_json = Column(Text, nullable=True) # e.g., prompt, model used for generation
+
+    project = relationship("Project", back_populates="images")
+    source_image = relationship("Image", remote_side=[id], backref="generated_from_this") # Self-referential for source image
+    annotations = relationship("Annotation", back_populates="image")
+
+
+class Label(Base): # Represents an object category/class
+    __tablename__ = "labels"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
+    name = Column(String, nullable=False, index=True) # e.g., "car", "person", "unknown"
+    color_hex = Column(String, nullable=True) # Optional, for UI display
+
+    project = relationship("Project", back_populates="labels")
+    annotations = relationship("Annotation", back_populates="label")
+
+    __table_args__ = (UniqueConstraint('project_id', 'name', name='_project_label_uc'),)
+
+
+class Annotation(Base): # Represents a single bounding box annotation
+    __tablename__ = "annotations"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    image_id = Column(Integer, ForeignKey("images.id"), nullable=False)
+    label_id = Column(Integer, ForeignKey("labels.id"), nullable=False) # Foreign key to the 'labels' table
+
+    x_min = Column(Float, nullable=False)
+    y_min = Column(Float, nullable=False)
+    x_max = Column(Float, nullable=False)
+    y_max = Column(Float, nullable=False)
+
+    confidence_score = Column(Float, nullable=True) # If from an AI model
+    source_type = Column(String, nullable=True) # e.g., 'manual', 'yolo_uniow_v1.0', 'gligen_v1.1'
+    is_unknown = Column(Boolean, default=False) # If flagged as 'unknown' by OWOD model initially
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    image = relationship("Image", back_populates="annotations")
+    label = relationship("Label", back_populates="annotations")
+
+# To ensure all models are known to Base before table creation,
+# you might need to import them in database.py before calling Base.metadata.create_all,
+# or ensure this file (models.py) is imported by an __init__.py in the db folder
+# which in turn is imported before create_db_and_tables is called.
+```

--- a/backend_api/app/main.py
+++ b/backend_api/app/main.py
@@ -1,0 +1,21 @@
+```python
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="Agile AI Vision Backend API",
+    description="API for supporting the Agile AI Vision application, interfacing with Label Studio and AI Model Servers.",
+    version="0.1.0",
+)
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to the Agile AI Vision Backend API"}
+
+# Further router includes will go here
+from .api import endpoints
+app.include_router(endpoints.router, prefix="/api/v1", tags=["ML Backend"])
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+```

--- a/backend_api/app/main.py
+++ b/backend_api/app/main.py
@@ -13,7 +13,16 @@ async def root():
 
 # Further router includes will go here
 from .api import endpoints
+from .db import database # Import database module
+
+# Create database tables on startup
+@app.on_event("startup")
+async def startup_db_client():
+    database.create_db_and_tables()
+    print("Database tables checked/created.")
+
 app.include_router(endpoints.router, prefix="/api/v1", tags=["ML Backend"])
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend_api/app/models/schemas.py
+++ b/backend_api/app/models/schemas.py
@@ -1,0 +1,121 @@
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+
+# --- General Schemas ---
+class Project(BaseModel):
+    project_id: Optional[int] = None
+    project_name: str
+    description: Optional[str] = None
+    config_json: Optional[str] = None # Label Studio labeling config
+
+    class Config:
+        orm_mode = True
+
+class Image(BaseModel):
+    image_id: Optional[int] = None
+    project_id: int
+    original_file_path: str
+    generated_file_path: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    source_image_id: Optional[int] = None
+    generation_params_json: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+class Label(BaseModel):
+    label_id: Optional[int] = None
+    project_id: int
+    label_name: str
+    color_hex: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+class Annotation(BaseModel):
+    annotation_id: Optional[int] = None
+    image_id: int
+    label_id: int
+    x_min: float
+    y_min: float
+    x_max: float
+    y_max: float
+    confidence_score: Optional[float] = None
+    source_type: Optional[str] = None # 'manual', 'yolo-uniow', 'gligen_generated'
+    is_unknown: Optional[bool] = False
+
+    class Config:
+        orm_mode = True
+
+
+# --- API Specific Schemas (matching Label Studio ML Backend expectations where applicable) ---
+
+# For Label Studio /predict endpoint request (simplified, actual can be more complex)
+class LabelStudioTaskItem(BaseModel):
+    id: int # Task ID
+    data: Dict[str, Any] # Typically {"image": "url_or_path_to_image"}
+
+class LabelStudioRequest(BaseModel):
+    tasks: List[LabelStudioTaskItem]
+    label_config: Optional[str] = None # XML Labeling config
+    project: Optional[str] = None # Project ID from Label Studio
+    params: Optional[Dict[str, Any]] = None # Other params like context
+
+# For Label Studio /predict endpoint response
+class LSAnnotationResultItemValue(BaseModel):
+    # For rectanglelabels
+    rectanglelabels: Optional[List[str]] = None
+    x: Optional[float] = None
+    y: Optional[float] = None
+    width: Optional[float] = None
+    height: Optional[float] = None
+    # Add other types like choices, keypoints etc. if needed
+    # Example for choices:
+    # choices: Optional[List[str]] = None
+
+class LSAnnotationResultItem(BaseModel):
+    from_name: str
+    to_name: str
+    type: str # e.g., "rectanglelabels", "choices"
+    value: LSAnnotationResultItemValue
+    score: Optional[float] = None # Confidence for this specific annotation item
+
+class LSPredictionItem(BaseModel):
+    result: List[LSAnnotationResultItem]
+    score: Optional[float] = None # Overall confidence for the task's prediction
+    model_version: Optional[str] = None
+    # cluster: Optional[Any] = None # For active learning
+    # neighbors: Optional[Any] = None # For active learning
+    # mislabeling: Optional[float] = 0 # For active learning
+
+# --- Schemas for our custom generation/suggestion endpoints ---
+
+class ObjectGenerationRequest(BaseModel):
+    image_path: str # Path to background image
+    target_bbox: List[float] = Field(..., min_items=4, max_items=4) # [x_min, y_min, x_max, y_max]
+    text_prompt: str
+    project_id: int
+
+class ObjectGenerationResponse(BaseModel):
+    new_image_path: str
+    annotation: Annotation # The annotation for the newly generated object
+
+class SceneEditRequest(BaseModel):
+    image_path: str
+    mask_data: str # Could be path to mask image or base64 encoded mask
+    text_prompt: str
+    project_id: int
+
+class SceneEditResponse(BaseModel):
+    edited_image_path: str
+
+class PromptSuggestionRequest(BaseModel):
+    base_keyword: str
+    project_id: Optional[int] = None # Context for suggestions
+
+class PromptSuggestionResponse(BaseModel):
+    suggestions: List[str]
+
+```

--- a/backend_api/app/models/schemas.py
+++ b/backend_api/app/models/schemas.py
@@ -1,110 +1,137 @@
 ```python
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
+from datetime import datetime
 
-# --- General Schemas ---
-class Project(BaseModel):
-    project_id: Optional[int] = None
-    project_name: str
-    description: Optional[str] = None
-    config_json: Optional[str] = None # Label Studio labeling config
+# --- Base Schemas (common fields for creation and reading) ---
+
+class ProjectBase(BaseModel):
+    name: str = Field(..., min_length=1, example="Project Alpha")
+    description: Optional[str] = Field(None, example="Initial project for detecting cars.")
+    config_json: Optional[str] = Field(None, example="<View>...</View>") # Label Studio labeling config
+
+class ProjectCreate(ProjectBase):
+    pass
+
+class Project(ProjectBase):
+    id: int
+    created_at: datetime # Should be populated by DB default
+    updated_at: Optional[datetime] = None # Should be populated by DB on update
 
     class Config:
         orm_mode = True
 
-class Image(BaseModel):
-    image_id: Optional[int] = None
+class ImageBase(BaseModel):
+    original_file_path: str = Field(..., example="/data/images/project_1/original/img_001.jpg")
+    generated_file_path: Optional[str] = Field(None, example="/data/images/project_1/generated/img_001_gen.jpg")
+    width: Optional[int] = Field(None, example=1920)
+    height: Optional[int] = Field(None, example=1080)
+    source_image_id: Optional[int] = Field(None, description="If generated, ID of the base image.")
+    generation_params_json: Optional[str] = Field(None, description="e.g., prompt, model used for generation.")
+
+class ImageCreate(ImageBase):
     project_id: int
-    original_file_path: str
-    generated_file_path: Optional[str] = None
-    width: Optional[int] = None
-    height: Optional[int] = None
-    source_image_id: Optional[int] = None
-    generation_params_json: Optional[str] = None
 
-    class Config:
-        orm_mode = True
-
-class Label(BaseModel):
-    label_id: Optional[int] = None
+class Image(ImageBase):
+    id: int
     project_id: int
-    label_name: str
-    color_hex: Optional[str] = None
+    uploaded_at: datetime # Should be populated by DB default
 
     class Config:
         orm_mode = True
 
-class Annotation(BaseModel):
-    annotation_id: Optional[int] = None
+class LabelBase(BaseModel):
+    name: str = Field(..., min_length=1, example="car")
+    color_hex: Optional[str] = Field(None, example="#FF0000")
+
+class LabelCreate(LabelBase):
+    project_id: int
+
+class Label(LabelBase):
+    id: int
+    project_id: int
+
+    class Config:
+        orm_mode = True
+
+class AnnotationBase(BaseModel):
+    x_min: float = Field(..., example=100.5)
+    y_min: float = Field(..., example=200.0)
+    x_max: float = Field(..., example=150.5)
+    y_max: float = Field(..., example=250.0)
+    confidence_score: Optional[float] = Field(None, example=0.95)
+    source_type: Optional[str] = Field(None, example="yolo_uniow_v1.0")
+    is_unknown: Optional[bool] = Field(False, example=False)
+
+class AnnotationCreate(AnnotationBase):
+    # image_id and label_id will be passed directly to CRUD, not part of this schema
+    # if we build annotations before we have the image/label DB records.
+    # Alternatively, if creating via an image, label_id is essential.
+    # For now, let's assume label_name will be used to find/create label_id in CRUD.
+    label_name: str # We'll use this to find/create the Label record and get its ID.
+
+class Annotation(AnnotationBase):
+    id: int
     image_id: int
     label_id: int
-    x_min: float
-    y_min: float
-    x_max: float
-    y_max: float
-    confidence_score: Optional[float] = None
-    source_type: Optional[str] = None # 'manual', 'yolo-uniow', 'gligen_generated'
-    is_unknown: Optional[bool] = False
+    created_at: datetime # Should be populated by DB default
+    updated_at: Optional[datetime] = None # Should be populated by DB on update
 
     class Config:
         orm_mode = True
-
 
 # --- API Specific Schemas (matching Label Studio ML Backend expectations where applicable) ---
 
-# For Label Studio /predict endpoint request (simplified, actual can be more complex)
+class LabelStudioTaskDataItem(BaseModel):
+    # Flexible data part of a task, often contains 'image' or other keys based on LS config
+    image: Optional[str] = None # Example: value of <Image name="image" value="$image_url" />
+    # Add other potential keys if your LS configs use them, e.g. text: Optional[str] = None
+
 class LabelStudioTaskItem(BaseModel):
-    id: int # Task ID
-    data: Dict[str, Any] # Typically {"image": "url_or_path_to_image"}
+    id: int # Task ID from Label Studio
+    data: LabelStudioTaskDataItem # More specific data type
 
 class LabelStudioRequest(BaseModel):
     tasks: List[LabelStudioTaskItem]
-    label_config: Optional[str] = None # XML Labeling config
-    project: Optional[str] = None # Project ID from Label Studio
-    params: Optional[Dict[str, Any]] = None # Other params like context
+    label_config: Optional[str] = Field(None, description="Label Studio XML Labeling Configuration")
+    project: Optional[str] = Field(None, description="Project ID from Label Studio (can be string ID)")
+    params: Optional[Dict[str, Any]] = Field(None, description="Other params like context from LS")
 
-# For Label Studio /predict endpoint response
 class LSAnnotationResultItemValue(BaseModel):
-    # For rectanglelabels
     rectanglelabels: Optional[List[str]] = None
     x: Optional[float] = None
     y: Optional[float] = None
     width: Optional[float] = None
     height: Optional[float] = None
-    # Add other types like choices, keypoints etc. if needed
-    # Example for choices:
-    # choices: Optional[List[str]] = None
+    # Add other LS types like: choices: Optional[List[str]] = None
 
 class LSAnnotationResultItem(BaseModel):
     from_name: str
     to_name: str
-    type: str # e.g., "rectanglelabels", "choices"
+    type: str # e.g., "rectanglelabels"
     value: LSAnnotationResultItemValue
-    score: Optional[float] = None # Confidence for this specific annotation item
+    score: Optional[float] = None
 
 class LSPredictionItem(BaseModel):
     result: List[LSAnnotationResultItem]
     score: Optional[float] = None # Overall confidence for the task's prediction
     model_version: Optional[str] = None
-    # cluster: Optional[Any] = None # For active learning
-    # neighbors: Optional[Any] = None # For active learning
-    # mislabeling: Optional[float] = 0 # For active learning
 
 # --- Schemas for our custom generation/suggestion endpoints ---
 
 class ObjectGenerationRequest(BaseModel):
-    image_path: str # Path to background image
+    image_path: str
     target_bbox: List[float] = Field(..., min_items=4, max_items=4) # [x_min, y_min, x_max, y_max]
     text_prompt: str
-    project_id: int
+    project_id: int # Assuming project_id is passed to know where to associate the generated image
 
 class ObjectGenerationResponse(BaseModel):
     new_image_path: str
-    annotation: Annotation # The annotation for the newly generated object
+    annotation: Annotation # Returns the full Annotation schema for the new object
 
 class SceneEditRequest(BaseModel):
     image_path: str
-    mask_data: str # Could be path to mask image or base64 encoded mask
+    mask_data: str
     text_prompt: str
     project_id: int
 
@@ -113,9 +140,8 @@ class SceneEditResponse(BaseModel):
 
 class PromptSuggestionRequest(BaseModel):
     base_keyword: str
-    project_id: Optional[int] = None # Context for suggestions
+    project_id: Optional[int] = None
 
 class PromptSuggestionResponse(BaseModel):
     suggestions: List[str]
-
 ```

--- a/backend_api/app/models/schemas.py
+++ b/backend_api/app/models/schemas.py
@@ -22,7 +22,7 @@ class Project(ProjectBase):
         orm_mode = True
 
 class ImageBase(BaseModel):
-    original_file_path: str = Field(..., example="/data/images/project_1/original/img_001.jpg")
+    original_file_path: Optional[str] = Field(None, example="/data/images/project_1/original/img_001.jpg") # Made optional
     generated_file_path: Optional[str] = Field(None, example="/data/images/project_1/generated/img_001_gen.jpg")
     width: Optional[int] = Field(None, example=1920)
     height: Optional[int] = Field(None, example=1080)
@@ -120,13 +120,14 @@ class LSPredictionItem(BaseModel):
 # --- Schemas for our custom generation/suggestion endpoints ---
 
 class ObjectGenerationRequest(BaseModel):
-    image_path: str
-    target_bbox: List[float] = Field(..., min_items=4, max_items=4) # [x_min, y_min, x_max, y_max]
-    text_prompt: str
-    project_id: int # Assuming project_id is passed to know where to associate the generated image
+    source_image_path: Optional[str] = Field(None, description="Path to an existing background image, if any.")
+    target_bbox: List[float] = Field(..., min_items=4, max_items=4, description="[x_min, y_min, x_max, y_max] for object placement.")
+    text_prompt: str = Field(..., description="Text prompt describing the object to generate.")
+    label_name_for_generated_object: str = Field(..., description="The class label to assign to the generated object.")
+    project_id: int
 
 class ObjectGenerationResponse(BaseModel):
-    new_image_path: str
+    new_image_path: str # Path to the newly created image (will be the generated_file_path)
     annotation: Annotation # Returns the full Annotation schema for the new object
 
 class SceneEditRequest(BaseModel):

--- a/backend_api/requirements.txt
+++ b/backend_api/requirements.txt
@@ -1,0 +1,10 @@
+```
+fastapi>=0.95.0,<0.111.0
+uvicorn[standard]>=0.21.0,<0.28.0
+pydantic>=1.10.0,<2.7.0
+pydantic-settings>=2.0.0,<2.2.0
+sqlalchemy>=2.0.0,<2.1.0
+# Add other specific dependencies here as needed, e.g.:
+# httpx # For making HTTP requests to model servers
+# Pillow # For image manipulation if any is done in the backend
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,12 @@ services:
       - yolo_uniow_model_server # Add dependencies as more model servers come online
     networks:
       - agile_ai_network
-    # healthcheck: # Optional healthcheck
-    #   test: ["CMD", "curl", "-f", "http://localhost:8000/"]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/"] # FastAPI root path
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s # Give it time to start up, especially with DB creation
 
   yolo_uniow_model_server:
     build:
@@ -81,6 +82,12 @@ services:
               capabilities: [gpu]
     networks:
       - agile_ai_network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"] # Health endpoint in yolo_uniow/serve.py
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s # Give it time for model loading if any
 
   # --- Placeholder services for other models (uncomment and configure as developed) ---
   # grounding_dino_model_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     # ports: # Not strictly needed if only backend_api accesses it
       # - "8001:8001"
     environment:
+      - IMAGE_BASE_DIR=/model_server/data/images/ # Base path inside this container for relative image paths
       # - MODEL_PATH=/model_server/weights/yolo_model.pt
       - NVIDIA_VISIBLE_DEVICES=all # If using GPU
     deploy: # For GPU support with docker-compose v2.3+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,122 @@
+```yaml
+version: '3.8'
+
+services:
+  label_studio:
+    image: heartexlabs/label-studio:latest # Use the latest official image
+    container_name: agile_ai_label_studio
+    ports:
+      - "8080:8080" # Expose Label Studio UI on host port 8080
+    volumes:
+      - ./data/label_studio_data:/label-studio/data # Persist Label Studio's internal data
+      # If Label Studio needs to serve images directly from the shared volume:
+      # - ./data/images:/app/data/images # Adjust path inside LS container if it serves local files
+    environment:
+      # Basic Label Studio settings
+      - LABEL_STUDIO_USERNAME=admin@example.com # Change as needed
+      - LABEL_STUDIO_PASSWORD=password          # Change as needed
+      - LABEL_STUDIO_BASE_SERVING_URL=/ # If serving from root
+      - DJANGO_DB=default # Use SQLite by default, LS manages this in its volume
+      # - DEBUG=1 # Optional: for more verbose logging from Label Studio
+      # ML Backend related (if LS directly starts ML backend, not common for separate FastAPI)
+      # Instead, you'll configure ML backends via the Label Studio UI,
+      # pointing to the 'backend_api' service URL.
+    depends_on:
+      - backend_api
+    networks:
+      - agile_ai_network
+
+  backend_api:
+    build:
+      context: ./backend_api
+      dockerfile: Dockerfile
+    container_name: agile_ai_backend_api
+    volumes:
+      - ./data/database:/app/data/database # Mount SQLite DB directory
+      - ./data/images:/app/data/images     # Mount shared image storage
+      # For development with live reload:
+      # - ./backend_api/app:/app/app
+    ports:
+      - "8000:8000" # Expose API port (optional, if you want to access it directly from host)
+    environment:
+      - DATABASE_URL=sqlite:///./data/database/metadata.db # Path inside the container
+      - IMAGE_STORAGE_BASE_PATH=./data/images             # Path inside the container
+      # Model Server URLs (these should match service names if on the same Docker network)
+      - YOLO_UNIOW_SERVER_URL=http://yolo_uniow_model_server:8001/infer
+      # Add other model server URLs as they are developed:
+      # - GROUNDING_DINO_SERVER_URL=http://grounding_dino_model_server:8002/infer
+      # - GLIGEN_SERVER_URL=http://gligen_model_server:8003/generate
+      # - CONTROLNET_SERVER_URL=http://controlnet_model_server:8004/edit
+      # - INTERNVL2_SERVER_URL=http://internvl2_model_server:8005/suggest
+    depends_on:
+      - yolo_uniow_model_server # Add dependencies as more model servers come online
+    networks:
+      - agile_ai_network
+    # healthcheck: # Optional healthcheck
+    #   test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+    #   interval: 30s
+    #   timeout: 10s
+    #   retries: 3
+
+  yolo_uniow_model_server:
+    build:
+      context: ./model_servers/yolo_uniow
+      dockerfile: Dockerfile
+    container_name: agile_ai_yolo_uniow_server
+    volumes:
+      # Mount model weights if they are not part of the Docker image
+      # - ./model_servers/yolo_uniow/weights:/model_server/weights
+      - ./data/images:/model_server/data/images # If model needs direct image access
+    # ports: # Not strictly needed if only backend_api accesses it
+      # - "8001:8001"
+    environment:
+      # - MODEL_PATH=/model_server/weights/yolo_model.pt
+      - NVIDIA_VISIBLE_DEVICES=all # If using GPU
+    deploy: # For GPU support with docker-compose v2.3+
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1 # Or 'all'
+              capabilities: [gpu]
+    networks:
+      - agile_ai_network
+
+  # --- Placeholder services for other models (uncomment and configure as developed) ---
+  # grounding_dino_model_server:
+  #   build: ./model_servers/grounding_dino
+  #   container_name: agile_ai_grounding_dino_server
+  #   # ... similar config to yolo_uniow_model_server ...
+  #   networks:
+  #     - agile_ai_network
+
+  # gligen_model_server:
+  #   build: ./model_servers/gligen
+  #   container_name: agile_ai_gligen_server
+  #   # ... GPU config essential ...
+  #   networks:
+  #     - agile_ai_network
+
+  # controlnet_model_server:
+  #   build: ./model_servers/controlnet_sd3
+  #   container_name: agile_ai_controlnet_server
+  #   # ... GPU config essential ...
+  #   networks:
+  #     - agile_ai_network
+
+  # internvl2_model_server:
+  #   build: ./model_servers/internvl2
+  #   container_name: agile_ai_internvl2_server
+  #   # ... GPU config might be needed ...
+  #   networks:
+  #     - agile_ai_network
+
+volumes:
+  label_studio_data: # Named volume for Label Studio's internal data
+  shared_images:     # If you prefer named volumes over bind mounts for images
+  shared_database:   # If you prefer named volumes for the database
+
+networks:
+  agile_ai_network:
+    driver: bridge
+```

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -1,0 +1,164 @@
+```markdown
+# Testing Guide: Agile AI Vision Application
+
+This guide outlines the steps to test the core pre-annotation workflow of the Agile AI Vision Application. This involves running the Dockerized backend services, a locally hosted Label Studio ML backend script, and Label Studio itself.
+
+## Prerequisites
+
+*   Docker and Docker Compose installed.
+*   Project cloned and you are in the root directory (`agile-ai-vision/`).
+*   Python environment with `label-studio-ml` installed (for running the ML backend script locally):
+    ```bash
+    pip install label-studio-ml requests
+    ```
+*   Label Studio installed and runnable (can be a local pip install or its own Docker container if preferred, but ensure network visibility as per below). For simplicity, this guide assumes a local pip install of Label Studio for UI interaction.
+    ```bash
+    pip install label-studio
+    ```
+*   An image file (e.g., `test_image.jpg`) available on your host machine for uploading to Label Studio.
+
+## I. Running Backend Services with Docker Compose
+
+1.  **Ensure Docker is running.**
+2.  **Host Data Directory Setup:**
+    *   This project expects a shared data directory on your host machine. By default, this is `agile-ai-vision/data/images/`.
+    *   Inside this directory, it's recommended to organize images by project, e.g., `agile-ai-vision/data/images/my_project_1/image1.jpg`.
+    *   Create these directories if they don't exist:
+        ```bash
+        # From your project root (agile-ai-vision/)
+        mkdir -p ./data/images/project_test/original
+        mkdir -p ./data/database
+        mkdir -p ./data/label_studio_data
+        ```
+    *   Place a test image (e.g., `cat.jpg`) into `./data/images/project_test/original/`.
+
+3.  **Environment Variables:**
+    *   Copy `.env.example` to `.env` if you haven't already: `cp .env.example .env`.
+    *   **Crucially for ML Backend Script (if paths are absolute):** If your Label Studio provides absolute local file paths, and your project root `agile-ai-vision/` is, for example, at `/home/user/dev/agile-ai-vision/`, you might need to set `HOST_DATA_IMAGES_ROOT` when running the ML backend script later. The script defaults this to `../data/images` relative to its own location, which should resolve correctly if you run `label-studio-ml start` from the `agile-ai-vision` root.
+        ```bash
+        # Example: if your project is at /home/user/dev/agile-ai-vision
+        # and you run the ML script from the project root, the default should work.
+        # HOST_DATA_IMAGES_ROOT will be /home/user/dev/agile-ai-vision/data/images
+        ```
+
+4.  **Start the Dockerized services:**
+    Open a terminal in the project root (`agile-ai-vision/`) and run:
+    ```bash
+    docker-compose up --build
+    ```
+    *   `--build` ensures images are rebuilt if there are changes.
+    *   Do not use `-d` (detached mode) for this initial test, so you can see logs from all services (`backend_api`, `yolo_uniow_model_server`, and `label_studio` if you were running it via compose) directly in this terminal.
+    *   You should see logs indicating that `backend_api` started (e.g., "Uvicorn running on http://0.0.0.0:8000") and `yolo_uniow_model_server` started (e.g., "YOLO-UniOW Model Server started. Mock model active.").
+    *   The `label_studio` service defined in `docker-compose.yml` will also start. You can access its UI at `http://localhost:8080`.
+
+## II. Running the Label Studio ML Backend Script Locally
+
+1.  **Open a new terminal window/tab.** Navigate to the project root.
+2.  **Set the `FASTAPI_PREDICT_URL` environment variable (optional, if different from default):**
+    The script `label_studio_ml_backend/yolo_preannotation_backend.py` defaults to `http://localhost:8000/api/v1/predict`. This should be correct if `backend_api`'s port 8000 is exposed to your host machine by Docker.
+    ```bash
+    # On Linux/macOS (optional, if default is fine)
+    # export FASTAPI_PREDICT_URL="http://localhost:8000/api/v1/predict"
+    # On Windows (PowerShell)
+    # $env:FASTAPI_PREDICT_URL="http://localhost:8000/api/v1/predict"
+    ```
+3.  **Start the ML backend script:**
+    ```bash
+    label-studio-ml start ./label_studio_ml_backend --script ./label_studio_ml_backend/yolo_preannotation_backend.py -p 9090
+    ```
+    *   This command tells `label-studio-ml` to serve the `YoloPreannotationBackend` class found in the specified script.
+    *   It will typically run on `http://localhost:9090` (or the IP of your machine if accessed from elsewhere).
+    *   You should see logs like "INFO:label_studio_ml.server: εποχές [epochs]: 0" and "INFO:label_studio_ml.server:Your server running at http://localhost:9090".
+    *   You should also see: `INFO:__main__:ML Backend using HOST_DATA_IMAGES_ROOT: /path/to/your/agile-ai-vision/data/images` (the actual absolute path). Verify this path is correct.
+
+## III. Configuring and Using Label Studio
+
+1.  **Access Label Studio UI:** Open your browser to `http://localhost:8080` (this uses the Label Studio instance started by `docker-compose`).
+    *   Log in with credentials from `docker-compose.yml` (default: `admin@example.com` / `password`).
+    *   Create a new project (e.g., "Test YOLO Preannotation").
+
+2.  **Configure Labeling Interface:**
+    *   In your project, go to `Settings` -> `Labeling Interface`.
+    *   Click `Browse Templates` and choose (or create) a template for **Object Detection with Bounding Boxes**.
+    *   Example minimal config:
+        ```xml
+        <View>
+          <Image name="image" value="$image_url"/>
+          <RectangleLabels name="label" toName="image">
+            <Label value="Car" background="green"/>
+            <Label value="Person" background="blue"/>
+            <Label value="Unknown" background="grey"/>
+          </RectangleLabels>
+        </View>
+        ```
+        *   **Important:** The `<Image name="image" .../>` means the ML backend script should expect image data under the key `"image"` in the task data. `yolo_preannotation_backend.py`'s `self.value` will parse to `"image"`.
+        *   The `<RectangleLabels name="label" .../>` means `from_name` will be `"label"`.
+
+4.  **Connect to the ML Backend:**
+    *   In project `Settings` -> `Machine Learning`.
+    *   Click `Add Model`.
+    *   **Title:** "My YOLOv8 Backend" (or any title).
+    *   **URL:** `http://localhost:9090` (This is where your `label-studio-ml start` script is running).
+    *   Toggle "Use for interactive preannotations".
+    *   Click `Validate and Save`. It should connect successfully.
+
+5.  **Configure Data Storage (Crucial for Local Files):**
+    *   In project `Settings` -> `Cloud Storage`.
+    *   Click `Add Source Storage`.
+    *   Choose `Local files`.
+    *   **Absolute local path:** Enter the **absolute path** on your host machine to the `agile-ai-vision/data/images` directory.
+        *   Example Linux/macOS: `/home/user/dev/agile-ai-vision/data/images`
+        *   Example Windows: `C:\Users\user\dev\agile-ai-vision\data\images`
+    *   **File filter regex:** `.*` (to sync all files) or be more specific e.g., `project_test/original/.*\.jpg`
+    *   Check "Treat every bucket object as a source file".
+    *   Click `Add Storage`. Then click `Sync Storage`.
+    *   This makes Label Studio aware of your local image files. The paths it generates for tasks will be based on this root.
+
+6.  **Import Data (Alternative to Syncing Cloud Storage):**
+    *   If not using the "Cloud Storage" sync method above for local files, you can use the standard "Import" button.
+    *   When Label Studio asks for file paths during import, or if you upload files, the paths it stores and passes to the ML backend are critical. The ML backend script's `HOST_DATA_IMAGES_ROOT` is designed to make these paths relative if they are absolute and start with that root.
+
+7.  **Test Pre-annotation:**
+    *   Open the imported image for labeling.
+    *   The ML backend should be automatically queried.
+    *   You should see bounding boxes predicted by the (mocked) YOLO server appear on the image. These will be "mock_car" and "unknown" based on current mock logic.
+
+## IV. What to Check
+
+1.  **Label Studio ML Backend Script Logs (Terminal 2):**
+    *   Look for lines indicating it received tasks (e.g., "Received 1 tasks for prediction.").
+    *   Check for logs about sending requests to `http://localhost:8000/api/v1/predict`.
+    *   Crucially, check logs like:
+        *   `INFO:__main__:Initialized YoloPreannotationBackend. FastAPI Predict URL: http://localhost:8000/api/v1/predict`
+        *   `INFO:__main__:ML Backend using HOST_DATA_IMAGES_ROOT: /actual/path/to/agile-ai-vision/data/images`
+        *   `INFO:__main__:Converted absolute path /actual/path/to/agile-ai-vision/data/images/project_test/original/cat.jpg to relative path project_test/original/cat.jpg ...` (or similar, depending on how LS provides the path).
+        *   `INFO:__main__:Sending request to FastAPI backend: ... with data: {'image': 'project_test/original/cat.jpg'}` (or similar relative path).
+    *   Look for logs about receiving predictions from FastAPI and any potential errors.
+
+2.  **Docker Compose Logs (Terminal 1 - `backend_api` service):**
+    *   Look for logs from `uvicorn` indicating a POST request to `/api/v1/predict`.
+    *   Example: `INFO:     172.19.0.1:0 - "POST /api/v1/predict HTTP/1.1" 200 OK`
+    *   Check for print statements like "Received /predict request for 1 tasks. Project identifier: <your_project_id_or_name>".
+    *   The `image_url_or_path` logged here should be the *relative path* (e.g., `project_test/original/cat.jpg`).
+    *   Look for "Calling YOLO server..." with the same relative path.
+    *   Check for database interaction logs.
+
+3.  **Docker Compose Logs (Terminal 1 - `yolo_uniow_model_server` service):**
+    *   Look for logs indicating a POST request to its `/infer` endpoint.
+    *   Example: `INFO:     172.20.0.3:50884 - "POST /infer HTTP/1.1" 200 OK` (IP will be `backend_api`'s Docker IP)
+    *   Check for `INFO:__main__:Received inference request for relative path: project_test/original/cat.jpg, resolved to: /model_server/data/images/project_test/original/cat.jpg ...`. This confirms the YOLO server correctly reconstructs the absolute path inside its container.
+    *   Check for "Returning ... predictions...".
+
+4.  **Database Check (Optional, more advanced):**
+    *   You can connect to the SQLite database (`agile-ai-vision/data/database/metadata.db`) using a tool like DB Browser for SQLite.
+    *   Check the `projects`, `images`, `labels`, and `annotations` tables for new entries corresponding to your test.
+
+## Troubleshooting Common Issues
+
+*   **Networking:**
+    *   "Connection refused" when ML backend script tries to call FastAPI: Ensure `backend_api` port 8000 is correctly exposed in `docker-compose.yml` (`ports: - "8000:8000"`) and `FASTAPI_PREDICT_URL` is `http://localhost:8000/...`.
+    *   "Connection refused" when FastAPI tries to call `yolo_uniow_model_server`: Ensure service names and ports in `YOLO_UNIOW_SERVER_URL` (`http://yolo_uniow_model_server:8001/infer`) match `docker-compose.yml`. Services in the same Docker network can reach each other by service name.
+*   **Image Paths:** If using local file storage in Label Studio, the paths provided in tasks must be resolvable by the `backend_api` and subsequently by the `yolo_uniow_model_server`. This often requires careful volume mounting in `docker-compose.yml` so that a path like `/data/my_image.jpg` on the host maps to the *same path* or a *predictably translatable path* inside all relevant containers. For initial tests, using image URLs (if LS is configured to serve them or from cloud storage) or ensuring very simple, consistent mount points is easiest. The current setup mounts `./data/images` from host to `/app/data/images` in `backend_api` and `/model_server/data/images` in `yolo_uniow_model_server`. This path difference means `image_url_or_path` passed from `backend_api` to `yolo_uniow_model_server` would need translation if it's an absolute path from `backend_api`'s perspective.
+    *   **Simplification for Test:** The guide now emphasizes setting up Label Studio "Local files" source storage with an absolute path to `agile-ai-vision/data/images` on the host. The ML backend script then attempts to make paths relative to `HOST_DATA_IMAGES_ROOT`. This relative path (e.g., `project_test/original/cat.jpg`) is what `backend_api` receives and passes to `yolo_uniow_model_server`. The `yolo_uniow_model_server` then prepends its internal `IMAGE_BASE_DIR` (e.g., `/model_server/data/images/`) to this relative path. This chain should work if all components' base paths correctly map to the host's `./data/images` via Docker volumes.
+*   **JSON Formatting/Pydantic Errors:** Check logs for Pydantic validation errors if the structure of data sent or received doesn't match schemas.
+```

--- a/label_studio_ml_backend/yolo_preannotation_backend.py
+++ b/label_studio_ml_backend/yolo_preannotation_backend.py
@@ -1,0 +1,186 @@
+```python
+import os
+import requests # To call the FastAPI backend
+import logging
+from typing import List, Dict, Any, Optional
+from uuid import uuid4
+
+from label_studio_ml.model import LabelStudioMLBase
+from label_studio_ml.utils import get_image_local_path, get_image_url, \
+    get_label_config, DATA_UNDEFINED_NAME, is_skipped
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# --- Configuration ---
+# URL of your FastAPI backend's /predict endpoint
+# Ensure this matches the FastAPI service name and port in docker-compose.yml and the correct endpoint path
+FASTAPI_PREDICT_URL = os.getenv("FASTAPI_PREDICT_URL", "http://backend_api:8000/api/v1/predict")
+# If your FastAPI backend needs an API key (good practice for security)
+FASTAPI_API_KEY = os.getenv("FASTAPI_API_KEY", None) # Example: "your_secret_api_key"
+
+
+class YoloPreannotationBackend(LabelStudioMLBase):
+    """
+    Label Studio ML Backend for YOLO-UniOW pre-annotations via a FastAPI backend.
+    """
+
+    def __init__(self, **kwargs):
+        super(YoloPreannotationBackend, self).__init__(**kwargs)
+
+        # Preload model (if any part of it is managed by this script directly)
+        # For this setup, the actual model is in a separate FastAPI service.
+        # This ML backend script primarily acts as a client to that service.
+
+        # Parse labeling config to get names of <Image> and <Label> tags
+        # This is important for formatting results correctly for Label Studio
+        self.from_name, self.to_name, self.value, self.labels_in_config = \
+            self._get_labeling_config_details()
+
+        logger.info(f"Initialized YoloPreannotationBackend. FastAPI Predict URL: {FASTAPI_PREDICT_URL}")
+        logger.info(f"Labeling Config Details: from_name={self.from_name}, to_name={self.to_name}, value={self.value}")
+
+    def _get_labeling_config_details(self):
+        """Helper to parse label config."""
+        try:
+            config = get_label_config(self.labeling_interface.config)
+            from_name, schema = list(config.items())[0]
+            to_name = schema['to_name'][0]
+            value = schema['inputs'][0]['value']
+            labels_in_config = set(config.get('labels_in_config', [])) # If labels are pre-defined in config
+            return from_name, to_name, value, labels_in_config
+        except Exception as e:
+            logger.error(f"Error parsing label config: {e}. Using defaults.")
+            # Fallback defaults if parsing fails, adjust as needed
+            return "label", "image", "image", set()
+
+
+    def predict(self, tasks: List[Dict], context: Optional[Dict] = None, **kwargs) -> List[Dict]:
+        """
+        Main prediction method called by Label Studio.
+        :param tasks: A list of tasks to process. Each task is a dictionary.
+        :param context: Optional context dictionary from Label Studio.
+        :return: A list of predictions in Label Studio format.
+        """
+        predictions = []
+        if not tasks:
+            logger.info("No tasks received for prediction.")
+            return predictions
+
+        logger.info(f"Received {len(tasks)} tasks for prediction.")
+
+        # Prepare data to send to the FastAPI backend
+        # This might involve just sending task IDs or image URLs/paths
+        # depending on how your FastAPI backend is designed to fetch data.
+
+        # For this example, let's assume FastAPI backend expects a structure
+        # similar to what Label Studio provides, or at least image URLs/paths.
+
+        # The FastAPI /predict endpoint expects a schemas.LabelStudioRequest model.
+        # We need to transform the tasks list into this structure.
+
+        api_tasks: List[Dict[str, Any]] = []
+        task_id_map: Dict[int, int] = {} # To map original task index to submitted task index
+
+        for i, task in enumerate(tasks):
+            # Assuming self.value holds the key for the image URL/path in task['data']
+            # e.g. if LS config is <Image name="image" value="$image_url" />, self.value is "image_url"
+            # However, LS usually provides data under a key like "image" or "text" directly.
+            # Let's assume the key for image data is `self.value` which was parsed from config (e.g. "image")
+            image_data_key = self.value
+            image_url_or_path = task['data'].get(image_data_key)
+
+            if not image_url_or_path:
+                logger.warning(f"Task {task.get('id')} (index {i}) has no image data for key '{image_data_key}'. Skipping.")
+                # We'll add an empty prediction later for tasks that couldn't be processed
+                continue
+
+            # The FastAPI endpoint schemas.LabelStudioRequest expects task.data to be a dict.
+            # And its sub-schema schemas.LabelStudioTaskItem expects task.data.image (or the key used in from_name/to_name)
+            # Ensure the data sent to FastAPI matches its expected input schema.
+            # The key in task.data should be the one specified in <Image value="$key_name" />
+            # For simplicity, if self.value is 'image', then task.data = {"image": image_url_or_path} is expected by FastAPI
+            api_tasks.append({
+                "id": task.get("id", i), # Use original task ID or index if not present
+                "data": {image_data_key: image_url_or_path} # e.g. {"image": "url/path"}
+            })
+            task_id_map[i] = len(api_tasks) -1 # Map original task index to its index in api_tasks
+
+        if not api_tasks:
+            logger.info("No valid tasks with image data to send to backend.")
+            # Return empty predictions for all original tasks
+            return [{"result": [], "score": 0} for _ in tasks]
+
+        request_payload = {
+            "tasks": api_tasks,
+            "label_config": self.labeling_interface.config,
+            "project": str(self.project_id) if self.project_id else None, # Ensure project_id is string or None
+             # "params": context # Pass context if your backend uses it
+        }
+
+        headers = {"Content-Type": "application/json"}
+        if FASTAPI_API_KEY:
+            headers["X-API-Key"] = FASTAPI_API_KEY
+
+        logger.info(f"Sending request to FastAPI backend: {FASTAPI_PREDICT_URL} with {len(api_tasks)} tasks.")
+
+        try:
+            response = requests.post(FASTAPI_PREDICT_URL, json=request_payload, headers=headers, timeout=120)
+            response.raise_for_status()
+
+            backend_predictions_list = response.json() # This should be List[schemas.LSPredictionItem]
+
+            # Reconstruct predictions list in the original order of tasks
+            # and handle tasks that were skipped or failed at the backend.
+            final_predictions = [{"result": [], "score": 0} for _ in tasks] # Initialize for all original tasks
+
+            if not isinstance(backend_predictions_list, list) or len(backend_predictions_list) != len(api_tasks):
+                logger.error(f"Unexpected response format or length from FastAPI. Expected list of {len(api_tasks)} items. Got: {type(backend_predictions_list)} len {len(backend_predictions_list) if isinstance(backend_predictions_list, list) else 'N/A'}")
+                return final_predictions # Return initialized empty predictions
+
+            for original_task_idx, submitted_task_idx in task_id_map.items():
+                if submitted_task_idx < len(backend_predictions_list):
+                    # Ensure the backend prediction matches Pydantic structure, though it's already validated by FastAPI's response_model
+                    # Here we just pass it through as it should be correctly formatted by FastAPI.
+                    final_predictions[original_task_idx] = backend_predictions_list[submitted_task_idx]
+                else: # Should not happen if lengths match
+                    logger.error(f"Mismatch in task mapping for task index {original_task_idx}")
+
+
+            logger.info(f"Processed {len(final_predictions)} predictions corresponding to original tasks.")
+            return final_predictions
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"HTTP Request to FastAPI backend failed: {e}", exc_info=True)
+            return [{"result": [], "score": 0} for _ in tasks]
+        except Exception as e:
+            logger.error(f"An error occurred during prediction processing: {e}", exc_info=True)
+            return [{"result": [], "score": 0} for _ in tasks]
+
+
+    def fit(self, event, data, **kwargs):
+        """
+        This method is called training (fitting) model.
+        Not used in this example as training is handled by a separate process/script.
+        """
+        logger.info("fit() method called, but not implemented in this YOLO pre-annotation backend.")
+        pass
+
+if __name__ == '__main__':
+    # This part is for local testing of the ML backend script (optional)
+    # It's not run when Label Studio uses the script.
+    logger.info("Running YoloPreannotationBackend locally for testing (mocked).")
+    # To test, you would need to simulate Label Studio's input (tasks, config).
+    # Example:
+    # ml_backend = YoloPreannotationBackend(project_id="1")
+    # ml_backend.labeling_interface = type('obj', (object,), {
+    #    'config': '<View><Image name="image" value="$image_url"/><RectangleLabels name="label" toName="image"><Label value="Car"/><Label value="Person"/></RectangleLabels></View>'
+    # })
+    # ml_backend.from_name, ml_backend.to_name, ml_backend.value, _ = ml_backend._get_labeling_config_details()
+
+    # test_tasks = [{"id": 1, "data": {"image_url": "https://example.com/image1.jpg"}}]
+    # preds = ml_backend.predict(test_tasks)
+    # logger.info(f"Mocked local prediction: {preds}")
+    pass
+```

--- a/label_studio_ml_backend/yolo_preannotation_backend.py
+++ b/label_studio_ml_backend/yolo_preannotation_backend.py
@@ -14,11 +14,29 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # --- Configuration ---
-# URL of your FastAPI backend's /predict endpoint
-# Ensure this matches the FastAPI service name and port in docker-compose.yml and the correct endpoint path
-FASTAPI_PREDICT_URL = os.getenv("FASTAPI_PREDICT_URL", "http://backend_api:8000/api/v1/predict")
-# If your FastAPI backend needs an API key (good practice for security)
-FASTAPI_API_KEY = os.getenv("FASTAPI_API_KEY", None) # Example: "your_secret_api_key"
+# URL of your FastAPI backend's /predict endpoint.
+# IMPORTANT NETWORKING CONSIDERATIONS:
+# - If this ML backend script is run ON THE HOST machine (e.g., using `label-studio-ml start .`):
+#   And the FastAPI backend (`backend_api` service) is running in Docker with port 8000 exposed to the host,
+#   then `localhost:8000` (or `127.0.0.1:8000`) should be used.
+# - If this ML backend script is ALSO run as a Docker container WITHIN THE SAME Docker network as `backend_api`:
+#   Then `http://backend_api:8000/...` would be correct.
+# We are assuming the first case for local development and testing with `label-studio-ml start`.
+FASTAPI_PREDICT_URL = os.getenv("FASTAPI_PREDICT_URL", "http://localhost:8000/api/v1/predict")
+
+# If your FastAPI backend needs an API key (good practice for security) - currently not implemented in FastAPI
+FASTAPI_API_KEY = os.getenv("FASTAPI_API_KEY", None)
+
+# Define the assumed root directory on the HOST machine where Label Studio's local file storage is based.
+# This path should correspond to what's mounted into the Docker containers at `./data/images`.
+# Example: If your project root is /home/user/agile-ai-vision, then HOST_DATA_IMAGES_ROOT would be /home/user/agile-ai-vision/data/images
+# It's crucial this is set correctly for local file paths to be made relative.
+# For robustness, this should ideally come from an environment variable.
+HOST_DATA_IMAGES_ROOT = os.getenv("HOST_DATA_IMAGES_ROOT", os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'images')))
+logger.info(f"ML Backend using HOST_DATA_IMAGES_ROOT: {HOST_DATA_IMAGES_ROOT}")
+# Ensure this path exists, or at least warn if it doesn't seem right, although the script doesn't access it directly.
+if not os.path.isdir(HOST_DATA_IMAGES_ROOT) and len(HOST_DATA_IMAGES_ROOT) > 3 : # Basic check
+    logger.warning(f"Configured HOST_DATA_IMAGES_ROOT '{HOST_DATA_IMAGES_ROOT}' does not exist or is not a directory. Path relativity might be incorrect for local files.")
 
 
 class YoloPreannotationBackend(LabelStudioMLBase):
@@ -97,18 +115,53 @@ class YoloPreannotationBackend(LabelStudioMLBase):
                 continue
 
             # The FastAPI endpoint schemas.LabelStudioRequest expects task.data to be a dict.
-            # And its sub-schema schemas.LabelStudioTaskItem expects task.data.image (or the key used in from_name/to_name)
-            # Ensure the data sent to FastAPI matches its expected input schema.
-            # The key in task.data should be the one specified in <Image value="$key_name" />
-            # For simplicity, if self.value is 'image', then task.data = {"image": image_url_or_path} is expected by FastAPI
+            # Its sub-schema schemas.LabelStudioTaskDataItem expects a field like `image`.
+            # The key in `task.data` (e.g., `task.data['image']` or `task.data['my_image_key']`)
+            # is determined by the <Image value="$my_image_key" /> in Label Studio's labeling config.
+            # `self.value` should hold this key (e.g., "my_image_key" or "image").
+
+            # If Label Studio serves images from a local path (e.g., /data/upload/myimage.jpg)
+            # and the ML backend script runs on the host, this path might be directly usable if
+            # the FastAPI backend (in Docker) has this same path mounted as a volume from the host.
+            # Example: Host's /abs/path/to/data/upload/ is mounted to Docker's /app/data/images.
+            # If LS gives path /abs/path/to/data/upload/myimage.jpg, and FastAPI's IMAGE_STORAGE_BASE_PATH
+            # is /app/data/images, then FastAPI needs to know how to map or expect relative paths.
+            # For now, we pass the path as is. The FastAPI backend will use this path to call the
+            # YOLO server, which also needs access to this path (e.g., via another shared volume).
+            # This path mapping across LS <-> ML script (host) <-> FastAPI (Docker) <-> YOLO server (Docker)
+            # is the most complex part of local file handling.
+            # Using URLs served by Label Studio (if configured for cloud storage) simplifies this.
+
+            # Attempt to make the path relative to HOST_DATA_IMAGES_ROOT
+            # This is crucial if image_url_or_path is an absolute path from the host system.
+            processed_image_path = image_url_or_path
+            if os.path.isabs(image_url_or_path) and HOST_DATA_IMAGES_ROOT:
+                if image_url_or_path.startswith(HOST_DATA_IMAGES_ROOT):
+                    processed_image_path = os.path.relpath(image_url_or_path, HOST_DATA_IMAGES_ROOT)
+                    # On Windows, relpath might produce backslashes, ensure forward slashes for cross-platform/URL compatibility
+                    processed_image_path = processed_image_path.replace(os.sep, '/')
+                    logger.info(f"Converted absolute path {image_url_or_path} to relative path {processed_image_path} using root {HOST_DATA_IMAGES_ROOT}")
+                else:
+                    logger.warning(f"Absolute path {image_url_or_path} does not start with HOST_DATA_IMAGES_ROOT {HOST_DATA_IMAGES_ROOT}. Sending path as is. This might fail in backend.")
+            elif "://" in image_url_or_path: # It's a URL, pass as is. Backend needs to handle fetching.
+                logger.info(f"Passing URL {image_url_or_path} as is to backend.")
+                # NOTE: Current backend/YOLO server mock expects file paths, not URLs. This would need handling there.
+                # For now, this test guide focuses on local file paths.
+            else: # Already a relative path or a non-HTTP URL, pass as is.
+                 logger.info(f"Passing path {image_url_or_path} as is (assumed relative or special scheme).")
+
+
+            api_task_data = {image_data_key: processed_image_path}
+            # If other data fields from the task are needed by the backend, add them here.
+
             api_tasks.append({
-                "id": task.get("id", i), # Use original task ID or index if not present
-                "data": {image_data_key: image_url_or_path} # e.g. {"image": "url/path"}
+                "id": task.get("id", i),
+                "data": api_task_data
             })
-            task_id_map[i] = len(api_tasks) -1 # Map original task index to its index in api_tasks
+            task_id_map[i] = len(api_tasks) -1
 
         if not api_tasks:
-            logger.info("No valid tasks with image data to send to backend.")
+            logger.info("No valid tasks with processable image paths to send to backend.")
             # Return empty predictions for all original tasks
             return [{"result": [], "score": 0} for _ in tasks]
 

--- a/model_servers/yolo_uniow/Dockerfile
+++ b/model_servers/yolo_uniow/Dockerfile
@@ -1,0 +1,24 @@
+```dockerfile
+# Start with a Python base image that includes appropriate ML libraries or is built upon an NVIDIA CUDA image
+# For CPU:
+FROM python:3.10-slim
+# For GPU (example, choose one that matches your PyTorch/CUDA needs):
+# FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
+
+WORKDIR /model_server
+
+# Copy requirements first
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the server code
+COPY ./serve.py /model_server/serve.py
+# If you have model weights or other assets, copy them too
+# COPY ./model_weights /model_server/model_weights
+
+EXPOSE 8001
+
+# Command to run the server
+# Ensure this matches how you want to run your FastAPI app (e.g., if serve.py is the entrypoint)
+CMD ["uvicorn", "serve:app", "--host", "0.0.0.0", "--port", "8001"]
+```

--- a/model_servers/yolo_uniow/requirements.txt
+++ b/model_servers/yolo_uniow/requirements.txt
@@ -1,0 +1,14 @@
+```
+fastapi>=0.95.0,<0.111.0
+uvicorn[standard]>=0.21.0,<0.28.0
+pydantic>=1.10.0,<2.7.0
+
+# Add ML specific libraries here
+# For YOLO, you'd typically need PyTorch and torchvision
+# torch>=1.13.0
+# torchvision>=0.14.0
+# ultralytics (if using YOLOv8 or similar from Ultralytics)
+
+# Placeholder for now, as actual model code is mocked
+# Add other dependencies like OpenCV (opencv-python-headless), numpy, etc. as needed
+```

--- a/model_servers/yolo_uniow/serve.py
+++ b/model_servers/yolo_uniow/serve.py
@@ -1,0 +1,106 @@
+```python
+from fastapi import FastAPI, HTTPException, Body
+from pydantic import BaseModel
+from typing import List, Dict, Any
+import logging # For logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# This is a placeholder for actual model loading and inference.
+# In a real scenario, you would load your YOLO-UniOW model here (e.g., using PyTorch).
+# For now, we'll mock the inference.
+
+# --- Pydantic Models for Request and Response ---
+class InferenceRequest(BaseModel):
+    image_path: str # Or image_bytes: bytes, or image_url: str
+    # Add any other parameters the model needs, e.g., confidence_threshold
+    confidence_threshold: float = 0.25
+
+class BoundingBox(BaseModel):
+    x_min: float
+    y_min: float
+    x_max: float
+    y_max: float
+    label: str
+    score: float
+
+class InferenceResponse(BaseModel):
+    predictions: List[BoundingBox]
+
+# --- FastAPI Application ---
+app = FastAPI(
+    title="YOLO-UniOW Model Server",
+    description="Serves the YOLO-UniOW model for object detection.",
+    version="0.1.0"
+)
+
+# --- Model Loading (Placeholder) ---
+# class YOLOUniOWModel:
+#     def __init__(self, model_path="path/to/yolo_uniow_weights.pt"):
+#         logger.info(f"Initializing YOLO-UniOW model from {model_path}...")
+#         # Load your PyTorch model, set to eval mode, move to device (CPU/GPU)
+#         # self.model = ...
+#         # self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+#         # self.model.to(self.device)
+#         logger.info("YOLO-UniOW model initialized (mocked).")
+
+#     def predict(self, image_path: str, confidence_threshold: float) -> List[BoundingBox]:
+#         logger.info(f"Predicting on image: {image_path} with threshold: {confidence_threshold}")
+#         # Actual preprocessing, inference, and postprocessing would go here
+#         # For now, return mocked data
+#         mock_predictions = [
+#             BoundingBox(x_min=50, y_min=50, x_max=150, y_max=150, label="known_object_1", score=0.85),
+#             BoundingBox(x_min=200, y_min=100, x_max=250, y_max=180, label="unknown", score=0.70),
+#         ]
+#         return [p for p in mock_predictions if p.score >= confidence_threshold]
+
+# model = YOLOUniOWModel() # Instantiate the model when the server starts
+
+@app.on_event("startup")
+async def startup_event():
+    # Initialize model here if it's better for your setup (e.g. with Gunicorn workers)
+    logger.info("YOLO-UniOW Model Server started. Mock model active.")
+    # global model
+    # model = YOLOUniOWModel() # If you define model globally
+
+@app.post("/infer", response_model=InferenceResponse, summary="Perform Object Detection")
+async def infer(request: InferenceRequest = Body(...)):
+    """
+    Receives an image path (or data) and returns object detection predictions.
+    """
+    logger.info(f"Received inference request for image: {request.image_path}")
+    try:
+        # In a real implementation:
+        # image = load_image(request.image_path) # Function to load image
+        # predictions = model.predict(image, request.confidence_threshold)
+
+        # Mocked prediction logic:
+        if "error" in request.image_path: # Simulate an error
+            raise ValueError("Simulated processing error for image.")
+
+        predictions = [
+            BoundingBox(x_min=50, y_min=50, x_max=150, y_max=150, label="mock_car", score=0.92),
+            BoundingBox(x_min=200, y_min=100, x_max=280, y_max=190, label="unknown", score=0.75),
+        ]
+        # Filter by confidence if model doesn't do it internally
+        # predictions = [p for p in raw_predictions if p.score >= request.confidence_threshold]
+
+        logger.info(f"Returning {len(predictions)} predictions.")
+        return InferenceResponse(predictions=predictions)
+    except Exception as e:
+        logger.error(f"Error during inference: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/health", summary="Health Check")
+async def health_check():
+    # Can be expanded to check model readiness
+    return {"status": "ok", "model_type": "YOLO-UniOW (Mocked)"}
+
+if __name__ == "__main__":
+    import uvicorn
+    # This is mainly for local testing of this server.
+    # In Docker, Uvicorn will be run as specified in the Dockerfile or docker-compose.yml.
+    uvicorn.run(app, host="0.0.0.0", port=8001)
+```

--- a/model_servers/yolo_uniow/serve.py
+++ b/model_servers/yolo_uniow/serve.py
@@ -7,17 +7,23 @@ import logging # For logging
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+import os # For path joining and environment variables
 
 # This is a placeholder for actual model loading and inference.
 # In a real scenario, you would load your YOLO-UniOW model here (e.g., using PyTorch).
 # For now, we'll mock the inference.
 
+# --- Configuration ---
+IMAGE_BASE_DIR_INSIDE_CONTAINER = os.getenv("IMAGE_BASE_DIR", "/model_server/data/images/")
+logger.info(f"YOLO Server using IMAGE_BASE_DIR: {IMAGE_BASE_DIR_INSIDE_CONTAINER}")
+
+
 # --- Pydantic Models for Request and Response ---
 class InferenceRequest(BaseModel):
-    image_path: str # Path to the image, accessible by this server
+    image_path: str # Path to the image, RELATIVE to IMAGE_BASE_DIR_INSIDE_CONTAINER
     confidence_threshold: float = 0.25
 
-class PredictedBoundingBox(BaseModel): # Renamed for clarity from internal BoundingBox
+class PredictedBoundingBox(BaseModel):
     x_min: float
     y_min: float
     x_max: float
@@ -69,25 +75,27 @@ async def startup_event():
 @app.post("/infer", response_model=InferenceResponse, summary="Perform Object Detection")
 async def infer(request: InferenceRequest = Body(...)):
     """
-    Receives an image path and returns object detection predictions.
-    The image path should be accessible by this server (e.g., a shared volume).
+    Receives a RELATIVE image path and returns object detection predictions.
+    The image path is joined with IMAGE_BASE_DIR_INSIDE_CONTAINER to get the absolute path.
     """
-    logger.info(f"Received inference request for image: {request.image_path} with threshold: {request.confidence_threshold}")
+    absolute_image_path = os.path.join(IMAGE_BASE_DIR_INSIDE_CONTAINER, request.image_path)
+    logger.info(f"Received inference request for relative path: {request.image_path}, resolved to: {absolute_image_path}, threshold: {request.confidence_threshold}")
 
     # Simulate file access check (in real scenario, you'd try to load the image)
-    # For example: if not os.path.exists(request.image_path):
-    # logger.error(f"Image not found at path: {request.image_path}")
-    # raise HTTPException(status_code=404, detail=f"Image not found: {request.image_path}")
+    # For example:
+    # if not os.path.exists(absolute_image_path):
+    #     logger.error(f"Image not found at resolved path: {absolute_image_path}")
+    #     raise HTTPException(status_code=404, detail=f"Image not found at resolved path: {absolute_image_path}")
 
     try:
         # In a real implementation:
-        # image = Image.open(request.image_path) # Example using Pillow
+        # image = Image.open(absolute_image_path) # Example using Pillow
         # results = actual_yolo_model.predict(image, conf=request.confidence_threshold)
         # predictions = format_results_to_predictedboundingbox(results)
 
         # Mocked prediction logic:
-        if "error_test_image.jpg" in request.image_path: # Simulate an error for a specific image
-            logger.error("Simulated processing error for image 'error_test_image.jpg'.")
+        if "error_test_image.jpg" in request.image_path: # Simulate an error based on relative path
+            logger.error(f"Simulated processing error for image '{request.image_path}'.")
             raise ValueError("Simulated processing error for image.")
 
         # Example mock predictions
@@ -100,14 +108,14 @@ async def infer(request: InferenceRequest = Body(...)):
         # Filter by confidence (as a real model might do, or post-process here)
         predictions = [p for p in raw_predictions if p.score >= request.confidence_threshold]
 
-        logger.info(f"Returning {len(predictions)} predictions for {request.image_path}.")
+        logger.info(f"Returning {len(predictions)} predictions for {absolute_image_path}.")
         return InferenceResponse(predictions=predictions)
 
     except ValueError as ve: # Specific error handling
-        logger.error(f"ValueError during inference for {request.image_path}: {ve}", exc_info=True)
+        logger.error(f"ValueError during inference for {absolute_image_path}: {ve}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(ve)) # Bad request if value error
     except Exception as e:
-        logger.error(f"Generic error during inference for {request.image_path}: {e}", exc_info=True)
+        logger.error(f"Generic error during inference for {absolute_image_path}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Internal server error during inference: {e}")
 
 @app.get("/health", summary="Health Check")

--- a/model_servers/yolo_uniow/serve.py
+++ b/model_servers/yolo_uniow/serve.py
@@ -14,11 +14,10 @@ logger = logging.getLogger(__name__)
 
 # --- Pydantic Models for Request and Response ---
 class InferenceRequest(BaseModel):
-    image_path: str # Or image_bytes: bytes, or image_url: str
-    # Add any other parameters the model needs, e.g., confidence_threshold
+    image_path: str # Path to the image, accessible by this server
     confidence_threshold: float = 0.25
 
-class BoundingBox(BaseModel):
+class PredictedBoundingBox(BaseModel): # Renamed for clarity from internal BoundingBox
     x_min: float
     y_min: float
     x_max: float
@@ -27,7 +26,9 @@ class BoundingBox(BaseModel):
     score: float
 
 class InferenceResponse(BaseModel):
-    predictions: List[BoundingBox]
+    predictions: List[PredictedBoundingBox]
+    model_name: str = "YOLO-UniOW_Mock"
+    version: str = "0.1.0"
 
 # --- FastAPI Application ---
 app = FastAPI(
@@ -51,8 +52,8 @@ app = FastAPI(
 #         # Actual preprocessing, inference, and postprocessing would go here
 #         # For now, return mocked data
 #         mock_predictions = [
-#             BoundingBox(x_min=50, y_min=50, x_max=150, y_max=150, label="known_object_1", score=0.85),
-#             BoundingBox(x_min=200, y_min=100, x_max=250, y_max=180, label="unknown", score=0.70),
+#             PredictedBoundingBox(x_min=50, y_min=50, x_max=150, y_max=150, label="known_object_1", score=0.85),
+#             PredictedBoundingBox(x_min=200, y_min=100, x_max=250, y_max=180, label="unknown", score=0.70),
 #         ]
 #         return [p for p in mock_predictions if p.score >= confidence_threshold]
 
@@ -68,30 +69,46 @@ async def startup_event():
 @app.post("/infer", response_model=InferenceResponse, summary="Perform Object Detection")
 async def infer(request: InferenceRequest = Body(...)):
     """
-    Receives an image path (or data) and returns object detection predictions.
+    Receives an image path and returns object detection predictions.
+    The image path should be accessible by this server (e.g., a shared volume).
     """
-    logger.info(f"Received inference request for image: {request.image_path}")
+    logger.info(f"Received inference request for image: {request.image_path} with threshold: {request.confidence_threshold}")
+
+    # Simulate file access check (in real scenario, you'd try to load the image)
+    # For example: if not os.path.exists(request.image_path):
+    # logger.error(f"Image not found at path: {request.image_path}")
+    # raise HTTPException(status_code=404, detail=f"Image not found: {request.image_path}")
+
     try:
         # In a real implementation:
-        # image = load_image(request.image_path) # Function to load image
-        # predictions = model.predict(image, request.confidence_threshold)
+        # image = Image.open(request.image_path) # Example using Pillow
+        # results = actual_yolo_model.predict(image, conf=request.confidence_threshold)
+        # predictions = format_results_to_predictedboundingbox(results)
 
         # Mocked prediction logic:
-        if "error" in request.image_path: # Simulate an error
+        if "error_test_image.jpg" in request.image_path: # Simulate an error for a specific image
+            logger.error("Simulated processing error for image 'error_test_image.jpg'.")
             raise ValueError("Simulated processing error for image.")
 
-        predictions = [
-            BoundingBox(x_min=50, y_min=50, x_max=150, y_max=150, label="mock_car", score=0.92),
-            BoundingBox(x_min=200, y_min=100, x_max=280, y_max=190, label="unknown", score=0.75),
+        # Example mock predictions
+        raw_predictions = [
+            PredictedBoundingBox(x_min=50.0, y_min=50.0, x_max=150.0, y_max=150.0, label="mock_car", score=0.92),
+            PredictedBoundingBox(x_min=200.0, y_min=100.0, x_max=280.0, y_max=190.0, label="unknown", score=0.75),
+            PredictedBoundingBox(x_min=10.0, y_min=10.0, x_max=40.0, y_max=40.0, label="low_score_obj", score=0.15),
         ]
-        # Filter by confidence if model doesn't do it internally
-        # predictions = [p for p in raw_predictions if p.score >= request.confidence_threshold]
 
-        logger.info(f"Returning {len(predictions)} predictions.")
+        # Filter by confidence (as a real model might do, or post-process here)
+        predictions = [p for p in raw_predictions if p.score >= request.confidence_threshold]
+
+        logger.info(f"Returning {len(predictions)} predictions for {request.image_path}.")
         return InferenceResponse(predictions=predictions)
+
+    except ValueError as ve: # Specific error handling
+        logger.error(f"ValueError during inference for {request.image_path}: {ve}", exc_info=True)
+        raise HTTPException(status_code=400, detail=str(ve)) # Bad request if value error
     except Exception as e:
-        logger.error(f"Error during inference: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Generic error during inference for {request.image_path}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Internal server error during inference: {e}")
 
 @app.get("/health", summary="Health Check")
 async def health_check():

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,257 @@
+```markdown
+# Product Requirements Document: Agile AI Vision Application
+
+## 1. Introduction
+
+### 1.1. Purpose
+This document outlines the requirements for an Agile AI Vision Application designed for non-technical users. The primary purpose of this application is to empower users to rapidly develop, deploy, and iteratively improve AI vision models by establishing a self-improving "living system" rather than relying on static, periodically trained models. It aims to democratize AI model enhancement by directly involving domain experts in the optimization loop.
+
+### 1.2. Scope
+The scope of this project includes the development of a full-stack application encompassing:
+*   A user-friendly web interface for data upload, annotation, model interaction, and data generation.
+*   Backend services for object detection, data synthesis, and model adaptation.
+*   Integration of advanced AI models for open-vocabulary detection, unknown object identification, and controllable image generation.
+*   A data management system for storing images and their associated metadata.
+*   Mechanisms for rapid model fine-tuning and performance tracking.
+
+The initial deployment will focus on local file system storage as per user requirements, with an architecture designed for future scalability.
+
+### 1.3. Background and Rationale
+Traditional AI model development follows a linear, costly, and time-consuming "collect-annotate-train-deploy" cycle, heavily reliant on technical specialists. This makes model updates slow and misaligned with dynamic business needs. The proposed system addresses these limitations by creating a "Data Flywheel" – a sustainable, self-driven AI ecosystem. This approach shifts the focus from mere data annotation to strategic data synthesis, enabling the system to proactively generate valuable training data. The core rationale is to significantly reduce the "value realization time" from problem discovery to solution deployment, thereby achieving cost reduction, increased efficiency, and rapid iteration capabilities for AI vision tasks.
+
+## 2. Goals and Objectives
+
+### 2.1. Primary Goals
+*   **Empower Non-Technical Users:** Enable domain experts, without requiring deep AI/coding knowledge, to directly contribute to and guide the improvement of AI vision models.
+*   **Achieve Rapid Iteration:** Drastically shorten the cycle time for model updates, corrections, and the introduction of new detection capabilities.
+*   **Reduce Costs and Increase Efficiency:** Minimize reliance on manual data collection/annotation and specialized AI personnel through intelligent automation and data synthesis.
+*   **Build a Self-Improving System:** Create a "Data Flywheel" where user interactions and AI-generated data continuously enhance model performance and robustness over time.
+*   **Shift from Data Consumption to Data Creation:** Transition from passively labeling existing data to actively synthesizing high-quality, targeted training data to address specific model deficiencies or new requirements.
+
+### 2.2. Secondary Objectives
+*   Provide a flexible and extensible platform capable of incorporating new AI models and techniques as they emerge.
+*   Offer clear metrics to track system performance and the effectiveness of the Data Flywheel.
+*   Ensure a high-quality user experience through an intuitive and responsive interface.
+
+## 3. Target Audience
+
+### 3.1. Primary Users
+*   **Non-technical domain experts:** Individuals with deep knowledge of specific business areas and visual data (e.g., quality control specialists, inventory managers, agricultural experts, security personnel) but without programming or AI modeling expertise. They are the primary users who will interact with the system to correct model outputs, define new object categories, and guide data generation.
+*   **Business analysts or operations managers:** Users who need to quickly adapt AI vision systems to changing business requirements, new products, or evolving operational environments without lengthy development cycles.
+
+### 3.2. Secondary Users (if any)
+*   **AI/ML Engineers (for setup and maintenance):** While the system is designed for non-technical end-users, AI/ML engineers may be involved in the initial setup, deployment, advanced configuration, and maintenance of the underlying models and infrastructure.
+*   **Data Curators/Managers (potentially):** Individuals responsible for overall data governance and quality, who might use the system's outputs and capabilities as part of a broader data strategy.
+
+## 4. User Needs & Pain Points Addressed
+
+The system aims to address the following key user needs and pain points:
+
+*   **Need for Speed and Agility:**
+    *   **Pain Point:** Current AI model development is too slow; adapting to new products or fixing errors takes weeks or months.
+    *   **Solution:** Enable rapid model updates, correction of misdetections, and addition of new object categories in significantly less time.
+*   **Ease of Use for Non-Experts:**
+    *   **Pain Point:** AI tools are complex and require specialized technical skills, creating a bottleneck.
+    *   **Solution:** Provide an intuitive, user-friendly interface that allows non-technical users to effectively guide AI model improvement without coding.
+*   **High Cost of AI Development and Maintenance:**
+    *   **Pain Point:** Extensive data collection, manual labeling, and reliance on AI experts are expensive.
+    *   **Solution:** Reduce costs through automated pre-annotation, AI-powered data synthesis (reducing manual labeling), and empowering existing domain experts.
+*   **Data Scarcity for Specific Needs:**
+    *   **Pain Point:** Lack of sufficient, diverse, and high-quality training data, especially for new or rare object categories or specific scenarios.
+    *   **Solution:** Enable users to guide the generation of synthetic data tailored to fill these gaps, effectively creating necessary data on demand.
+*   **Inefficient Error Correction Process:**
+    *   **Pain Point:** Identifying and correcting model errors (漏检 - missed detections, 错检 - false positives) is a tedious and manual process.
+    *   **Solution:** Streamline error correction through AI-assisted identification of potential errors (e.g., "unknown" objects) and intuitive tools for users to make corrections.
+*   **Static Models Unable to Cope with Change:**
+    *   **Pain Point:** Models trained once become outdated as real-world conditions, products, or requirements evolve.
+    *   **Solution:** Create a "living system" that continuously learns and adapts based on user feedback and new data, maintaining high performance over time.
+*   **Difficulty in Quantifying Model Improvement:**
+    *   **Pain Point:** It's hard to see if changes are actually making the AI better in a tangible way.
+    *   **Solution:** Provide clear KPIs to track model improvement and the efficiency of the data iteration process.
+
+## 5. Proposed Solution Overview
+
+### 5.1. Core Concept (Data Flywheel)
+The proposed solution is centered around a "Data Flywheel" model, a closed-loop feedback system designed to create a virtuous cycle of continuous model improvement through user-AI interaction. This model aims to transform traditional AI development into a dynamic, self-optimizing process. The flywheel consists of four key stages:
+
+1.  **Detect & Identify Gaps:** The system's core object detection model processes new, real-world business data. Any performance deficiencies (e.g., missed detections, incorrect identifications) are captured not as mere errors, but as valuable signals ("fuel") indicating areas for model improvement.
+2.  **User-Guided Correction & Augmentation:** Non-technical users interact with the system via an intuitive web interface. They correct model errors and, crucially, guide data augmentation by initiating data generation tasks, especially for new object categories or to address specific deficiencies.
+3.  **Intelligent Data Synthesis:** Based on user corrections and requests, the system's "Intelligent Data Synthesis Engine" employs generative AI techniques to create high-quality, precisely annotated training samples on demand. This includes generating variations of existing objects or synthesizing entirely new objects within specified contexts.
+4.  **Rapid Model Adaptation:** New data (user-corrected and AI-synthesized) is used to efficiently fine-tune or adapt the existing AI model. This process utilizes techniques like incremental learning or few-shot adaptation to quickly incorporate new knowledge without full retraining, ensuring the model continuously improves and avoids catastrophic forgetting.
+
+This cycle ensures that each iteration not only addresses immediate issues but also enhances the model's overall capability and generalization, reducing future manual intervention.
+
+### 5.2. Key Innovations
+*   **Shift from Annotation to Synthesis:** Moving beyond manual labeling to AI-assisted and AI-driven creation of core data assets.
+*   **Non-Technical User Empowerment:** Placing domain experts directly in the loop of model optimization.
+*   **Integrated Open-World and Generative AI:** Combining advanced detection models (capable of identifying "unknowns") with controllable generation techniques for targeted data creation.
+*   **Focus on "Time to Value":** Drastically reducing the time from problem identification/new need to a deployed, improved solution.
+
+## 6. Functional Requirements
+
+### 6.1. FR1: Data Ingestion and Management
+*   **6.1.1:** Users shall be able to upload image data (individual files and batches) into the system.
+*   **6.1.2:** The system shall store uploaded images on a local file system as per initial requirements.
+*   **6.1.3:** The system shall manage metadata associated with images, including file paths, annotations, and project configurations, using a lightweight database (SQLite).
+*   **6.1.4:** The system should provide basic project management capabilities (e.g., creating new projects, organizing data within projects).
+
+### 6.2. FR2: Object Detection Core
+The system must incorporate advanced object detection capabilities to serve as the foundation of the Data Flywheel.
+
+*   **6.2.1. Real-time Interactive Detection (YOLO-UniOW):**
+    *   **6.2.1.1:** The system shall use an efficient model (recommended: YOLO-UniOW) for real-time or near real-time pre-annotation of uploaded images in the user interface.
+    *   **6.2.1.2:** This model must provide immediate feedback to the user, suggesting bounding boxes and class labels for known objects.
+*   **6.2.2. High-Accuracy Offline Analysis (Grounding DINO):**
+    *   **6.2.2.1:** The system shall incorporate a high-accuracy model (recommended: Grounding DINO) for backend analysis tasks where precision is paramount.
+    *   **6.2.2.2:** This model can be used for batch processing or as a "locator" tool for the intelligent synthesis engine, especially when precise object localization is critical for generation.
+*   **6.2.3. Open Vocabulary Detection (OVD):**
+    *   **6.2.3.1:** The detection models shall support Open Vocabulary Detection, allowing users to define new object categories using natural language text dynamically.
+    *   **6.2.3.2:** The system must be able to detect these newly defined categories in images, even if the categories were not part of the model's original training set. This is crucial for "Time to New Capability."
+*   **6.2.4. Unknown Object Identification (Open World Object Detection - OWOD):**
+    *   **6.2.4.1:** The primary real-time detection model (YOLO-UniOW) shall possess Open World Detection capabilities, specifically the ability to identify and flag objects that do not belong to any of the currently known/defined categories as "unknown."
+    *   **6.2.4.2:** This "unknown object" flagging is critical for proactively identifying model blind spots (漏检) and guiding users to areas needing attention or new category definition, transforming error discovery from a manual search to a guided review.
+
+### 6.3. FR3: User-Guided Correction and Annotation
+The system must provide intuitive tools for users to correct AI model outputs and perform manual annotations when necessary.
+
+*   **6.3.1. Manual Annotation Tools:**
+    *   **6.3.1.1:** The user interface (Label Studio) shall provide standard annotation tools (e.g., bounding boxes, polygons if feasible in later stages).
+    *   **6.3.1.2:** Users shall be able to create, modify, and delete annotations.
+*   **6.3.2. Review and Correction of AI Outputs:**
+    *   **6.3.2.1:** Users shall be able to easily review pre-annotations and "unknown" object suggestions from the detection models.
+    *   **6.3.2.2:** Users shall be able to accept, reject, or modify these AI-generated suggestions (e.g., adjust bounding box coordinates, change or assign class labels).
+*   **6.3.3. Label Management:**
+    *   **6.3.3.1:** Users shall be able to define and manage a list of object categories (class labels) for each project.
+    *   **6.3.3.2:** This includes adding new categories, renaming existing ones, and potentially assigning colors or other visual aids for labels in the UI.
+    *   **6.3.3.3:** Corrected "unknown" objects should seamlessly be assignable to existing or newly created categories.
+
+### 6.4. FR4: Intelligent Data Synthesis Engine
+This engine is core to the system's innovation, enabling proactive data creation.
+
+*   **6.4.1. Automated Pre-annotation (covered by FR2.1):**
+    *   **6.4.1.1:** When new images are uploaded, the system (via YOLO-UniOW) shall automatically provide initial bounding boxes and labels as a starting point for the user, fulfilling the "automatic pre-annotation" need.
+*   **6.4.2. Controllable Object Generation (GLIGEN-based):**
+    *   **6.4.2.1:** The system shall allow users to generate new object instances within existing or new images, based on textual descriptions and user-specified locations (bounding boxes). (Recommended model: GLIGEN).
+    *   **6.4.2.2:** This feature is key for "为现有数据集快速增加新的检测类别" (adding new detection categories to existing datasets).
+    *   **6.4.2.3:** Generated objects should be realistically blended with the background image.
+    *   **6.4.2.4:** The system must automatically create and save the annotation (bounding box and class label) for the newly synthesized object.
+*   **6.4.3. Scene-Aware Inpainting/Modification (ControlNet-based):**
+    *   **6.4.3.1:** The system shall provide tools for more complex image editing, such as replacing an incorrectly identified object or modifying parts of an image while maintaining scene consistency (Recommended model: ControlNet + SD3).
+    *   **6.4.3.2:** Users should be able to define a region (mask) for modification and provide a textual prompt for the desired change.
+    *   **6.4.3.3:** The generation should respect the original image's context (e.g., lighting, perspective) using control signals like depth maps or edge maps.
+    *   **6.4.3.4:** This is crucial for correcting complex misdetections or augmenting scenes in a fine-grained manner.
+*   **6.4.4. Prompt Assistance (Prompt Co-pilot - InternVL2):**
+    *   **6.4.4.1:** To aid non-technical users in creating effective textual prompts for generative models, the system shall integrate a "Prompt Co-pilot" (Recommended LMM: InternVL2).
+    *   **6.4.4.2:** When a user provides a simple class name or concept for generation, the Prompt Co-pilot shall suggest a list of diverse, descriptive, and high-quality prompt templates.
+    *   **6.4.4.3:** Users should be able to select from these suggestions or use them as inspiration to refine their own prompts, improving the quality and diversity of generated data.
+
+### 6.5. FR5: Model Adaptation and Training
+The system must facilitate the rapid incorporation of new knowledge (from corrections and synthesis) into the AI models.
+
+*   **6.5.1. Rapid Model Fine-tuning/Adaptation:**
+    *   **6.5.1.1:** The system shall include mechanisms to trigger model fine-tuning or adaptation using the newly acquired/corrected annotated data and synthetically generated data.
+    *   **6.5.1.2:** This process should be efficient, focusing on incremental learning or few-shot adaptation techniques to minimize training time and computational cost, and to avoid catastrophic forgetting.
+*   **6.5.2. Mechanism to Trigger Re-training/Adaptation:**
+    *   **6.5.2.1:** While full automation of re-training triggers might be complex for MVP, the system should at least provide a straightforward way for an administrator or designated user to initiate the model adaptation process using the accumulated new data.
+    *   **6.5.2.2:** (Future) The system could explore heuristics to suggest when re-training might be beneficial (e.g., after a certain volume of new data is collected).
+
+### 6.6. FR6: User Interface and Workflow (Label Studio as Core)
+The application layer, centered around Label Studio, must provide a seamless and intuitive experience.
+
+*   **6.6.1. Integrated Platform:**
+    *   **6.6.1.1:** Label Studio shall serve as the primary user interface, orchestrating the entire human-in-the-loop workflow.
+    *   **6.6.1.2:** All user interactions – data upload, viewing pre-annotations, manual correction, triggering data synthesis, initiating prompt assistance – shall occur within this unified environment.
+*   **6.6.2. Intuitive Controls for Non-technical Users:**
+    *   **6.6.2.1:** The interface, including any custom actions for generation or prompt assistance, must be designed for users without a technical background.
+    *   **6.6.2.2:** Workflows for correcting detections, adding new classes, and generating data should be straightforward and require minimal training.
+*   **6.6.3. ML Backend Integration:**
+    *   **6.6.3.1:** Label Studio's ML Backend mechanism shall be used to integrate all custom AI model services (YOLO-UniOW for pre-annotation, GLIGEN/ControlNet for generation, InternVL2 for prompt assistance).
+    *   **6.6.3.2:** This integration should allow for bidirectional communication: Label Studio sending requests to the model services and receiving results (predictions, generated images, prompt suggestions) for display.
+*   **6.6.4. Custom UI Elements for AI Interactions:**
+    *   **6.6.4.1:** The Label Studio interface may need to be customized with specific buttons or controls to trigger data generation ("Generate Object with GLIGEN", "Edit with ControlNet") or prompt assistance ("Get Prompt Suggestions").
+*   **6.6.5. Visualization of Model Performance/KPIs (Basic):**
+    *   **6.6.5.1:** (Phase 3/Future) The system should provide a simple dashboard or view within Label Studio (or linked from it) to display the key performance indicators (KPIs) outlined in Section 8, allowing users to track model improvement over time.
+
+## 7. Non-Functional Requirements
+
+### 7.1. NFR1: Performance
+*   **7.1.1. Real-time Detection Latency (YOLO-UniOW):**
+    *   Pre-annotation of an image upon upload should ideally complete within a few seconds (e.g., < 5 seconds for typical image sizes) to ensure a fluid user experience. Target FPS for the model itself is high (e.g., YOLO-UniOW-L ~64.8 FPS on A100), but end-to-end latency including data transfer will be higher.
+*   **7.1.2. Data Generation Time (GLIGEN, ControlNet):**
+    *   Generation of a single new object instance (GLIGEN) or a scene modification (ControlNet) should ideally complete within a reasonable timeframe for interactive use (e.g., < 30-60 seconds). Batch generation can have longer timelines.
+*   **7.1.3. Model Adaptation Time:**
+    *   Rapid model adaptation/fine-tuning should be significantly faster than full retraining, ideally completable within hours rather than days, depending on the volume of new data.
+*   **7.1.4. UI Responsiveness:**
+    *   The Label Studio interface must be responsive, with minimal lag during common operations like drawing bounding boxes, changing labels, or navigating between tasks.
+
+### 7.2. NFR2: Usability
+*   **7.2.1. Ease of Use for Non-Technical Users:** The system must be highly intuitive and usable by individuals without a background in AI or software development. Workflows for common tasks (correction, generation) should be self-explanatory or require minimal documentation/training.
+*   **7.2.2. Clarity of AI Suggestions:** Pre-annotations and "unknown" object highlights must be clearly presented to the user.
+*   **7.2.3. Feedback Mechanisms:** The system should provide clear feedback to users on the status of operations (e.g., "generation in progress," "model training complete").
+
+### 7.3. NFR3: Data Management and Storage
+*   **7.3.1. Local File System Storage:** All raw image data and generated image files must be stored on the user's specified local file system.
+*   **7.3.2. Metadata Integrity (SQLite):** Annotation data, file paths, project configurations, and other metadata stored in SQLite must be accurate and consistently maintained.
+*   **7.3.3. Data Privacy:** Since data is stored locally, the system itself does not introduce new external data privacy concerns, but best practices for securing local data access should be considered by the user/deployer.
+*   **7.3.4. Data Backup:** The system itself will not provide automated backup of the local file system or SQLite database; this will be the user's responsibility. (This should be clearly communicated).
+
+### 7.4. NFR4: Scalability (Future Considerations)
+*   **7.4.1. Architectural Design for Scalability:** While initial deployment is local, the architecture (especially the separation of the Business Logic/API layer and Model Serving layer) should allow for future migration to cloud storage (e.g., S3) and more scalable database solutions with manageable effort. The use of an abstracted data access layer is recommended.
+*   **7.4.2. Model Serving Scalability:** The model serving layer should be designed to potentially scale independently, e.g., by deploying more instances of model servers if demand increases in a future cloud-based scenario.
+
+### 7.5. NFR5: Extensibility
+*   **7.5.1. Model Agnosticism (within reason):** The system should be designed to facilitate the integration of new or updated detection or generation models in the future with reasonable development effort, primarily by modifying the API/Business Logic Layer and Model Serving Layer.
+*   **7.5.2. Label Studio Customization:** Leverage Label Studio's inherent flexibility for adding new labeling configurations or custom UI elements as needed.
+
+### 7.6. NFR6: Maintainability
+*   **7.6.1. Code Modularity:** Backend services (FastAPI, model servers) should be developed with modularity in mind for easier updates and bug fixing.
+*   **7.6.2. Clear APIs:** APIs between Label Studio ML Backend, FastAPI service, and model servers must be well-defined and documented.
+*   **7.6.3. Configuration Management:** Key parameters (model paths, server addresses) should be configurable.
+
+### 7.7. NFR7: Deployment
+*   **7.7.1. Dockerized Deployment:** The entire system (Label Studio, FastAPI backend, model serving components) should be deployable using Docker and Docker Compose to simplify setup and ensure environment consistency.
+*   **7.7.2. Clear Installation Instructions:** Comprehensive documentation must be provided for setting up and running the system.
+
+## 8. Success Metrics (KPIs)
+The success of the Agile AI Vision Application will be measured against the following Key Performance Indicators (KPIs), as defined in Part 1.3 of the source document. These KPIs directly reflect the system's ability to deliver on its core promises of "降本增效" (cost reduction and efficiency increase) and "快速迭代" (rapid iteration).
+
+*   **8.1. Problem修正时间 (Time to Correct):**
+    *   **Definition:** The total time elapsed from the moment a business user identifies a model detection error in a practical application to the successful deployment of an updated model that includes the correction.
+    *   **Measures:** System agility and responsiveness to errors.
+*   **8.2. 新能力上线时间 (Time to New Capability):**
+    *   **Definition:** The end-to-end time taken from when a business or sales department requests the detection of a completely new object category to the point where the model possesses this new capability and is ready for operational use.
+    *   **Measures:** Efficiency in supporting business expansion and adapting to new requirements.
+*   **8.3. 标注效率 (Annotation Efficiency):**
+    *   **Definition:** The ratio of annotations generated or assisted by AI (including pre-annotations and synthesized data annotations) to the number of annotations that need to be created manually from scratch by a human, throughout the data iteration cycle.
+    *   **Measures:** The efficiency gains brought by the "Intelligent Data Synthesis Engine" and automated pre-annotation.
+*   **8.4. 模型性能提升率 (Model Performance Lift):**
+    *   **Definition:** The percentage increase in key model performance metrics (e.g., mean Average Precision - mAP) on a standardized evaluation dataset after each full cycle of the Data Flywheel.
+    *   **Measures:** The effectiveness of the Data Flywheel in driving continuous, measurable self-improvement of the AI model.
+
+These KPIs will serve as "North Star" metrics during development and operational phases to ensure all technical decisions align with the ultimate goals of enhancing system responsiveness, reducing operational costs, and continually improving core AI capabilities.
+
+## 9. Future Considerations / Potential Enhancements
+*   Cloud storage integration (e.g., AWS S3, Azure Blob Storage) for improved scalability and data management.
+*   More sophisticated database solutions for larger-scale deployments.
+*   Automated triggers for model re-training based on data volume or performance degradation.
+*   Advanced analytics and visualization of model performance trends.
+*   Support for a wider range of annotation types (e.g., semantic segmentation, instance segmentation).
+*   Integration with MLOps platforms for more robust model versioning, deployment, and monitoring.
+*   Multi-user collaboration features with role-based access control.
+
+## 10. Assumptions and Dependencies
+*   **Assumption:** Users will have access to hardware (potentially with GPUs) suitable for running the AI models, especially for model training/adaptation and efficient inference for generative models.
+*   **Assumption:** Non-technical users can be adequately trained to use the Label Studio interface and understand the concepts of correcting annotations and guiding data generation.
+*   **Dependency:** Availability and stability of the chosen open-source models (YOLO-UniOW, Grounding DINO, GLIGEN, ControlNet, InternVL2) and their underlying libraries (PyTorch, Diffusers, etc.).
+*   **Dependency:** Label Studio's ML backend functionality and its compatibility with the custom FastAPI service.
+*   **Dependency:** Python environment and necessary libraries can be consistently managed, likely via Docker.
+
+## 11. Out of Scope (for MVP / Initial Phases)
+*   Fully automated model retraining triggers without any human intervention.
+*   Advanced user management and role-based access control beyond basic Label Studio project separation.
+*   Direct integration with cloud-based managed AI training services.
+*   Real-time collaborative annotation by multiple users on the same task simultaneously (standard Label Studio behavior for task locking will apply).
+*   Support for data types other than images.
+*   Detailed performance optimization for extremely large datasets (tens of millions of images) – focus is on local, manageable datasets initially.
+*   Automated data backup and disaster recovery solutions (user responsibility for local deployments).
+```


### PR DESCRIPTION
…tion

- Configured FastAPI main app to include an API router with '/api/v1' prefix.
- Implemented a preliminary '/api/v1/predict' endpoint in FastAPI:
  - Uses Pydantic models for request (LabelStudioRequest) and response (List[LSPredictionItem]).
  - Contains mocked logic for generating pre-annotations, including 'unknown' labels.
  - Includes comments for future integration with the YOLO-UniOW model server.
- Updated LabelStudio ML backend script (`yolo_preannotation_backend.py`):
  - Adjusted `FASTAPI_PREDICT_URL` to point to the new `/api/v1/predict` endpoint.
  - Modified the request payload to conform to the `LabelStudioRequest` Pydantic model expected by FastAPI.
  - Improved mapping of responses back to original Label Studio tasks.
- This lays the groundwork for the core pre-annotation workflow.